### PR TITLE
Add build option to run in headless mode and exit immediately

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
            sudo apt-get update
-           sudo apt-get install libwayland-dev libwayland-server0 wayland-protocols libxkbcommon-dev libwayland-egl1 libegl-dev libdrm-dev libgles-dev libgbm-dev libinput-dev libudev-dev libpixman-1-dev libpixman-1-0 libxcb-composite0-dev xcb libxcb-render0-dev libxcb-xfixes0-dev xwayland
+           sudo apt-get install libwayland-dev libwayland-server0 wayland-protocols libxkbcommon-dev libwayland-egl1 libegl-dev libdrm-dev libgles-dev libgbm-dev libinput-dev libudev-dev libpixman-1-dev libpixman-1-0 libxcb-composite0-dev xcb libxcb-render0-dev libxcb-xfixes0-dev xwayland waybar swaybg
            python -m pip install --upgrade pip
            python -m pip install ninja
            python -m pip install meson

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Run vivarium (headless) and check for clean exit
         run: |
+          mkdir $XDG_RUNTIME_DIR
           ./build/src/vivarium
         env:
-            XDG_RUNTIME_DIR: ./
+            XDG_RUNTIME_DIR: xdg_runtime_dir

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,3 +58,5 @@ jobs:
       - name: Run vivarium (headless) and check for clean exit
         run: |
           ./build/src/vivarium
+        env:
+            XDG_RUNTIME_DIR: ./

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,3 +49,12 @@ jobs:
         run: |
           meson --reconfigure build -Dxwayland=enabled -Ddebug=true
           ninja -C build
+
+      - name: Build vivarium, debug=true xwayland=enabled headless-test=true
+        run: |
+          meson --reconfigure build -Dxwayland=enabled -Ddebug=true -Dheadless-test=true
+          ninja -C build
+
+      - name: Run vivarium (headless) and check for clean exit
+        run: |
+          ./build/src/vivarium

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
            sudo apt-get update
-           sudo apt-get install libwayland-dev libwayland-server0 wayland-protocols libxkbcommon-dev libwayland-egl1 libegl-dev libdrm-dev libgles-dev libgbm-dev libinput-dev libudev-dev libpixman-1-dev libpixman-1-0 libxcb-composite0-dev xcb libxcb-render0-dev libxcb-xfixes0-dev
+           sudo apt-get install libwayland-dev libwayland-server0 wayland-protocols libxkbcommon-dev libwayland-egl1 libegl-dev libdrm-dev libgles-dev libgbm-dev libinput-dev libudev-dev libpixman-1-dev libpixman-1-0 libxcb-composite0-dev xcb libxcb-render0-dev libxcb-xfixes0-dev xwayland
            python -m pip install --upgrade pip
            python -m pip install ninja
            python -m pip install meson

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build Vivarium
+name: Build and run Vivarium
 
 on:
   push:

--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -233,11 +233,11 @@ static struct viv_config the_config = {
     .clear_colour = { 0.73, 0.73, 0.73, 1.0 },
 
     // Background configuration. Applies to all outputs. Requires `swaybg` to be installed.
-    /* .background = { */
-        /* .colour = "#bbbbbb",  // note: this is overridden by .image if present */
-        /* .image = "/path/to/your/background.png", */
-        /* .mode = "fill",  // options from swaybg: stretch, fit, fill, center, tile, solid_color */
-    /* }, */
+    .background = {
+        .colour = "#bbbbbb",  // note: this is overridden by .image if present
+        .image = "/path/to/your/background.png",
+        .mode = "fill",  // options from swaybg: stretch, fit, fill, center, tile, solid_color
+    },
 
     // Use the keybinds list configured above.
     .keybinds = the_keybinds,
@@ -268,7 +268,7 @@ static struct viv_config the_config = {
 
     // Status bar configuration.
     .bar = {
-        .command = "",  // will be run when Vivarium starts
+        .command = "waybar",  // will be run when Vivarium starts
         .update_signal_number = 1,  // if non-zero, Vivarium sends (SIGRTMIN + update_signal_number)
                                     // to the bar process each time the workspace config changes,
                                     // can be used by the bar process as an update trigger

--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -233,11 +233,11 @@ static struct viv_config the_config = {
     .clear_colour = { 0.73, 0.73, 0.73, 1.0 },
 
     // Background configuration. Applies to all outputs. Requires `swaybg` to be installed.
-    .background = {
-        .colour = "#ff0000",  // note: this is overridden by .image if present
-        .image = "/home/sandy/sway_bg.jpg",
-        .mode = "fill",  // options from swaybg: stretch, fit, fill, center, tile, solid_color
-    },
+    /* .background = { */
+        /* .colour = "#bbbbbb",  // note: this is overridden by .image if present */
+        /* .image = "/path/to/your/background.png", */
+        /* .mode = "fill",  // options from swaybg: stretch, fit, fill, center, tile, solid_color */
+    /* }, */
 
     // Use the keybinds list configured above.
     .keybinds = the_keybinds,
@@ -268,7 +268,7 @@ static struct viv_config the_config = {
 
     // Status bar configuration.
     .bar = {
-        .command = "waybar",  // will be run when Vivarium starts
+        .command = "",  // will be run when Vivarium starts
         .update_signal_number = 1,  // if non-zero, Vivarium sends (SIGRTMIN + update_signal_number)
                                     // to the bar process each time the workspace config changes,
                                     // can be used by the bar process as an update trigger

--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,11 @@ if get_option('xwayland').enabled()
   ], language : 'c')
 endif
 
-
+if get_option('headless-test')
+  add_project_arguments([
+    '-DHEADLESS_TEST',
+    ], language : 'c')
+endif
 
 cc = meson.get_compiler('c')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('xwayland', type : 'feature', value : 'enabled', description : 'Include XWayland support')
 option('develop', type : 'boolean', value : true, description : 'Include debug logging and assertions')
 option('config-dir', type : 'string', value : 'config', description : 'Path to your config folder, must contain viv_config.h defining `struct viv_config the_config`')
+option('headless-test', type : 'boolean', value : false, description : 'Build Vivarium to immediately set up some headless devices then exit, for testing purposes only')

--- a/src/viv_background.c
+++ b/src/viv_background.c
@@ -28,7 +28,7 @@ static void run_swaybg(char *colour, char *image, char *mode) {
             NULL
         };
         execvp(cmd[0], cmd);
-        _exit(EXIT_FAILURE);
+        _exit(EXIT_SUCCESS);
     }
 }
 

--- a/src/viv_background.c
+++ b/src/viv_background.c
@@ -33,7 +33,10 @@ static void run_swaybg(char *colour, char *image, char *mode) {
 }
 
 void viv_parse_and_run_background_config(char *colour, char *image, char *mode) {
-    if (!strlen(colour) && !strlen(image) && !strlen(mode)) {
+    bool colour_valid = (colour != NULL) && strlen(colour);
+    bool image_valid = (image != NULL) && strlen(image);
+    bool mode_valid = (mode != NULL) && strlen(mode);
+    if (!colour_valid && !image_valid && !mode_valid) {
         // Nothing is configured so just don't run swaybg
         wlr_log(WLR_ERROR, "No background config, skipping");
         return;

--- a/src/viv_background.c
+++ b/src/viv_background.c
@@ -38,7 +38,7 @@ void viv_parse_and_run_background_config(char *colour, char *image, char *mode) 
     bool mode_valid = (mode != NULL) && strlen(mode);
     if (!colour_valid && !image_valid && !mode_valid) {
         // Nothing is configured so just don't run swaybg
-        wlr_log(WLR_ERROR, "No background config, skipping");
+        wlr_log(WLR_INFO, "No background config, skipping");
         return;
     }
 

--- a/src/viv_bar.c
+++ b/src/viv_bar.c
@@ -14,14 +14,14 @@ static pid_t run_bar(char *bar_command) {
 	if (pid == 0) {
         // TODO: We need to do more shenanigans to fork properly/safely, see e.g. sway's version
 
-        wlr_log(WLR_INFO, "Running swaybg");
+        wlr_log(WLR_INFO, "Running bar %s", bar_command);
 
         char *const cmd[] = {
             bar_command,
             NULL
         };
         execvp(cmd[0], cmd);
-        _exit(EXIT_FAILURE);
+        _exit(EXIT_SUCCESS);
     }
     return pid;
 }

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -7,6 +7,9 @@
 #include <wayland-server-core.h>
 #include <libinput.h>
 #include <wlr/backend.h>
+#ifdef HEADLESS_TEST
+#include <wlr/backend/headless.h>
+#endif
 #include <wlr/backend/libinput.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/types/wlr_compositor.h>
@@ -774,7 +777,12 @@ void viv_server_init(struct viv_server *server) {
 
     // Create a wlroots backend. This will automatically handle creating a suitable
     // backend for the environment, e.g. an X11 window if running under X.
+#ifdef HEADLESS_TEST
+    // Use a headless backend for CI testing without any actual outputs
+	server->backend = wlr_headless_backend_create(server->wl_display, NULL);
+#else
 	server->backend = wlr_backend_autocreate(server->wl_display, NULL);
+#endif
 
     // Init the default wlroots GLES2 renderer
 	server->renderer = wlr_backend_get_renderer(server->backend);

--- a/src/vivarium.c
+++ b/src/vivarium.c
@@ -75,6 +75,8 @@ int main(int argc, char *argv[]) {
     setenv("QT_QPA_PLATFORM", "wayland", true);
     setenv("GDK_BACKEND", "wayland", true);  // NOTE: not a typo, it really is GDK not GTK
 
+    return 0;
+
 #ifndef HEADLESS_TEST
     // Start the wayland eventloop. From here, all compositor activity comes via events it
     // sends us.


### PR DESCRIPTION
This lets the CI check that we don't accidentally introduce segfaults etc., especially on exit which is easier to miss during development.