### PR TITLE
Make default config run without needing any special environment

### DIFF
--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -253,10 +253,10 @@ static struct viv_config the_config = {
     // It is possible to set multiple toggling layouts via the normal xkb syntax (comma-separated)
 	.xkb_rules = {
         .rules = NULL,  // included for completion
-        .model = "pc104",
-        .layout = "widecolemak",
-        .variant = "widecolemak",
-        .options = "ctrl:nocaps",
+        .model = NULL,
+        .layout = "us",
+        .variant = NULL,
+        .options = NULL,
     },
 
     // Use the libinput configs list configured above.


### PR DESCRIPTION
Vivarium with the default config currently crashes on systems other than mine due to non-robust handling of the config loading and the fact that the config includes a default xkb keymap that nobody else has. This fixes that.