### PR TITLE
Fix xwayland window border drawing logic

### DIFF
--- a/src/viv_render.c
+++ b/src/viv_render.c
@@ -271,8 +271,8 @@ static void viv_render_xwayland_view(struct wlr_renderer *renderer, struct viv_v
     bool is_active_on_current_output = ((output == output->server->active_output) &
                                         (view == view->workspace->active_view));
     bool is_active = is_grabbed || is_active_on_current_output;
-    if (view->is_floating && !view->workspace->active_layout->no_borders &&
-        !view->is_static) {
+    if (!view->is_static &&
+        (view->is_floating || !view->workspace->active_layout->no_borders)) {
         render_borders(view, output, is_active);
     }
 


### PR DESCRIPTION
Borders were erroneously not being drawn due to a logic error in a
recent commit