### PR TITLE
Add damage tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,6 @@ Vivarium expects to be run from a TTY, but also supports embedding in an X sessi
 
 Vivarium comes with a default config that you can override by creating your own `config.toml`. You can also adjust the default config at compile time using `viv_config.h`, which is necessary if you want to inject your own code for e.g. custom layouts or adding keypress actions that aren't already provided by Vivarium.
 
-Configuration options include but are not limited to:
-
-* Custom hotkeys for all types of window manipulations.
-* Choose the list of layouts to use.
-* Window borders.
-* Keyboard layout(s).
-* Status bar configuration.
-* Background image/colour.
-* Mouse interaction options.
-
 ### config.toml
 
 **Use this if:** you've installed Vivarium and want to override its defaults with your own config.
@@ -126,32 +116,6 @@ Vivarium can automatically start a bar program such as [Waybar](https://github.c
 
 See `viv_config.h` or the `config.toml` for instructions on starting the bar program.
 
-To have Waybar update when signalled by Vivarium, set it up as below (instructions are for `config.h`):
-
-    // Choose a filename at which Vivarium will write a workspace status string
-    .ipc_workspaces_filename = "/path/to/status/file",
-
-    // Configure bar autostart
-    .bar = {
-        .command = "waybar",
-        .update_signal_number = 1,  // If non-zero, Vivarium sends the bar process
-                                    // SIGRTMIN + update_signal_number on changes
-    },
-
-Then in your Waybar config:
-
-    "modules-left": ["custom/workspaces"],
-
-    "custom/workspaces": {
-        "exec": "cat /path/to/status/file",
-        "interval": "once",
-        "signal": 1,
-        "format": " {} ",
-        "escape": true,
-    },
-
-Note that the `"signal"` option matches the `update_signal_number` from Vivarium's config, telling Waybar to refresh (re-read the status file) when the signal is received.
-
 ## FAQ (or not-so-FAQ)
 
 > What does "desktop semantics inspired by xmonad" mean?
@@ -166,6 +130,16 @@ Vivarium makes no attempt to rigorously mimic xmonad or to replicate its interna
 Vivarium attempts to tell windows not to draw their own decorations and this works for most applications, but the protocols for doing so are not yet standard or universally supported so some windows still draw their own. For now there's probably nothing you can do about it, but this is likely to improve in the future.
 
 It's also possible that there are bugs in Vivarium's window decoration configuration, bug reports welcome if so.
+
+> What's the status of Vivarium's damage tracking support?
+
+Vivarium supports damage tracking, i.e. drawing only regions of the screen that have actually changed, but this is semi-experimental.
+
+Damage tracking currently defaults to `"frame"`, which draws every frame in which something has changed anywhere on the screen. This is a dramatic improvement on rerendering all your unchanging windows every frame, but even better would be to have full damage tracking that redraws only the small parts of the frame that have actually changed.
+
+To test out full damage tracking, change the config value to `"full"`. This is tested and is thought to work if every monitor has the same scale, but there may be bugs in more complex output configurations. Full damage tracking will become the default as soon as these issues are resolved.
+
+If at any point you find Vivarium fails to render something (e.g. jerky frames, missing menu popups), try setting the config to `"none"`: if this makes it work then you've found a damage tracking issue. Either way, issue reports are [gratefully received](https://github.com/inclement/vivarium/issues).
 
 > Why TOML for configuration? How can I configure dynamic behaviour like my own layouts?
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Core features include:
 * Floating windows on demand.
 * (optional) XWayland support.
 * Layer shell support, compatible with tools like [Waybar](https://github.com/Alexays/Waybar), [bemenu](https://github.com/Cloudef/bemenu) and [swaybg](https://github.com/swaywm/swaybg).
+* Damage tracking for efficient rendering
 
 Vivarium is unstable and unfinished...but usable!
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Core features include:
 * Floating windows on demand.
 * (optional) XWayland support.
 * Layer shell support, compatible with tools like [Waybar](https://github.com/Alexays/Waybar), [bemenu](https://github.com/Cloudef/bemenu) and [swaybg](https://github.com/swaywm/swaybg).
-* Damage tracking for efficient rendering
+* Damage tracking.
 
 Vivarium is unstable and unfinished...but usable!
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -256,8 +256,8 @@ mark-active-output = false
 # to draw only damaged regions of damaged frames
 damage-tracking-mode = "frame"
 
-# Draw only damaged regions each frame, leaving the rest of the frame red.
-draw-only-damaged-regions = false
+# Draw the background red before drawing damaged regions, so only damaged regions are rendered
+mark-undamaged-regions = false
 
 # Draw a small square that cycles through red/green/blue each time a frame is drawn
 mark-frame-draws = false

--- a/config/config.toml
+++ b/config/config.toml
@@ -67,16 +67,6 @@ update-signal-number = 1
 # This is a hacky solution that will be deprecated at some point.
 # workspaces-filename = "/path/to/some/file.txt"
 
-### DEBUG ###
-# Vivarium debug options included for completion. You will want to leave these false under
-# normal operation.
-[debug]
-# Draw a graphical indicator of what shell (XDG, XWayland, Layer) is providing each window surface.
-mark-views-by-shell = false
-
-# Draw a graphical indicator of what shell (i.e. normally what monitor) is currently active.
-mark-active-output = false
-
 ### LAYOUTS ###
 # Configure any number of layouts. Each workspace gets an independent copy of each layout.
 # The following options are available for each layout:
@@ -251,3 +241,23 @@ scroll-button = 8
 middle-emulation = true
 left-handed = false
 natural-scroll = false
+
+### DEBUG ###
+# Vivarium debug options included for completion. You will want to leave these with their
+# default values under normal operation.
+[debug]
+# Draw a graphical indicator of what shell (XDG, XWayland, Layer) is providing each window surface.
+mark-views-by-shell = false
+
+# Draw a graphical indicator of what shell (i.e. normally what monitor) is currently active.
+mark-active-output = false
+
+# Damage tracking: "none" to draw every frame, "frame" to draw only damaged frames, "full"
+# to draw only damaged regions of damaged frames
+damage-tracking-mode = "frame"
+
+# Draw only damaged regions each frame, leaving the rest of the frame red.
+draw-only-damaged-regions = false
+
+# Draw a small square that cycles through red/green/blue each time a frame is drawn
+mark-frame-draws = false

--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -101,7 +101,7 @@ struct viv_keybind the_keybinds[] = {
     /// How to bind your own function rather than an existing command:
     KEYBIND_USER_FUNCTION(META, F, &example_user_function),
     KEYBIND_MAPPABLE(META, d, debug_damage_all),
-    KEYBIND_MAPPABLE(META, p, debug_swap_buffers), /*  */
+    KEYBIND_MAPPABLE(META, p, debug_swap_buffers),
     /// Autogenerate keybindings to switch to and/or send windows to each workspace:
     FOR_EACH_WORKSPACE(BIND_SWITCH_TO_WORKSPACE)
     FOR_EACH_WORKSPACE(BIND_SHIFT_ACTIVE_WINDOW_TO_WORKSPACE)

--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -252,8 +252,6 @@ static struct viv_config the_config = {
     // This exists for basic inter-process communication e.g. with waybar, see below
     .ipc_workspaces_filename = NULL,
 
-    .damage_tracking_mode = VIV_DAMAGE_TRACKING_FRAME,
-
     // Status bar configuration.
     .bar = {
         .command = "waybar",  // will be run when Vivarium starts
@@ -262,10 +260,15 @@ static struct viv_config the_config = {
                                     // can be used by the bar process as an update trigger
     },
 
+    // The damage tracking mode: NONE to fully render every frame, FRAME to render only
+    // frames with any damage, FULL to render only damaged regions of damaged frames.
+    // Note: the default is currently FRAME because FULL damage tracking may still be buggy
+    .damage_tracking_mode = VIV_DAMAGE_TRACKING_FRAME,
+
     // Debug options, not useful outside development:
     .debug_mark_views_by_shell = false,  // mark xdg windows with a green rect, xwayland by a red rect
     .debug_mark_active_output = false,  // draw a blue rectangle in the top left of the active output
-    .debug_draw_only_damaged_regions = false,  // draw only damaged regions leaving rest of output red
+    .debug_mark_undamaged_regions = false,  // draw only damaged regions leaving rest of output red
     .debug_mark_frame_draws = false,  // draw a small square that cycles through red/green/blue on frame draw
 };
 

--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -100,6 +100,8 @@ struct viv_keybind the_keybinds[] = {
     KEYBIND_MAPPABLE(NO_MODIFIERS, XF86AudioRaiseVolume, do_shell, .command = "amixer -q sset Master 3%+"),
     /// How to bind your own function rather than an existing command:
     KEYBIND_USER_FUNCTION(META, F, &example_user_function),
+    KEYBIND_MAPPABLE(META, d, debug_damage_all),
+    KEYBIND_MAPPABLE(META, p, debug_swap_buffers), /*  */
     /// Autogenerate keybindings to switch to and/or send windows to each workspace:
     FOR_EACH_WORKSPACE(BIND_SWITCH_TO_WORKSPACE)
     FOR_EACH_WORKSPACE(BIND_SHIFT_ACTIVE_WINDOW_TO_WORKSPACE)

--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -252,6 +252,8 @@ static struct viv_config the_config = {
     // This exists for basic inter-process communication e.g. with waybar, see below
     .ipc_workspaces_filename = NULL,
 
+    .damage_tracking_mode = VIV_DAMAGE_TRACKING_FRAME,
+
     // Status bar configuration.
     .bar = {
         .command = "waybar",  // will be run when Vivarium starts
@@ -263,6 +265,8 @@ static struct viv_config the_config = {
     // Debug options, not useful outside development:
     .debug_mark_views_by_shell = false,  // mark xdg windows with a green rect, xwayland by a red rect
     .debug_mark_active_output = false,  // draw a blue rectangle in the top left of the active output
+    .debug_draw_only_damaged_regions = false,  // draw only damaged regions leaving rest of output red
+    .debug_mark_frame_draws = false,  // draw a small square that cycles through red/green/blue on frame draw
 };
 
 

--- a/include/viv_cli.h
+++ b/include/viv_cli.h
@@ -1,6 +1,12 @@
 #ifndef VIV_CLI_H
 #define VIV_CLI_H
 
-void viv_cli_parse_args(int argc, char *argv[]);
+#include "viv_types.h"
+
+struct viv_args {
+    char *config_filen;
+};
+
+struct viv_args viv_cli_parse_args(int argc, char *argv[]);
 
 #endif

--- a/include/viv_damage.h
+++ b/include/viv_damage.h
@@ -1,0 +1,9 @@
+#ifndef VIV_DAMAGE_H
+#define VIV_DAMAGE_H
+
+#include "viv_types.h"
+
+/// Damage the given surface, which is placed at the given layout coords, on every output
+void viv_damage_surface(struct viv_server *server, struct wlr_surface *surface, int lx, int ly);
+
+#endif

--- a/include/viv_mappable_functions.h
+++ b/include/viv_mappable_functions.h
@@ -44,6 +44,7 @@ union viv_mappable_payload;
     MACRO(user_function, "Run a C function. Args: function (pointer (*function)(struct viv_workspace *workspace))", void (*function)(struct viv_workspace *workspace);) \
     MACRO(debug_damage_all, "Mark all outputs as damaged to force a full redraw") \
     MACRO(debug_swap_buffers, "Swap buffers") \
+    MACRO(debug_toggle_show_undamaged_regions, "Debug option to draw undamaged regions as red") \
 
 // Declare each mappable function and generate a payload struct to pass as its argument
 MACRO_FOR_EACH_MAPPABLE(GENERATE_DECLARATION)

--- a/include/viv_mappable_functions.h
+++ b/include/viv_mappable_functions.h
@@ -42,6 +42,8 @@ union viv_mappable_payload;
     MACRO(make_window_main, "Move active window to first position in current layout") \
     MACRO(reload_config, "Reload the config.toml (warning: may have weird results, restart vivarium if possible)") \
     MACRO(user_function, "Run a C function. Args: function (pointer (*function)(struct viv_workspace *workspace))", void (*function)(struct viv_workspace *workspace);) \
+    MACRO(debug_damage_all, "Mark all outputs as damaged to force a full redraw") \
+    MACRO(debug_swap_buffers, "Swap buffers") \
 
 // Declare each mappable function and generate a payload struct to pass as its argument
 MACRO_FOR_EACH_MAPPABLE(GENERATE_DECLARATION)

--- a/include/viv_output.h
+++ b/include/viv_output.h
@@ -33,6 +33,8 @@ void viv_output_damage_layout_coords_box(struct viv_output *output, struct wlr_b
 /// Damage the given region, expected to be unscaled an in output-layout coordinates
 void viv_output_damage_layout_coords_region(struct viv_output *output, pixman_region32_t *damage);
 
+void viv_output_layout_coords_box_to_output_coords(struct viv_output *output, struct wlr_box *geo_box);
+
 /// Mark that whatever workspace is active will need its layout function applying
 void viv_output_mark_for_relayout(struct viv_output *output);
 #endif

--- a/include/viv_output.h
+++ b/include/viv_output.h
@@ -27,6 +27,12 @@ void viv_output_do_layout_if_necessary(struct viv_output *output);
 /// Mark the whole output as damaged
 void viv_output_damage(struct viv_output *output);
 
+/// Damage the given box, expected to be unscaled and in output-layout coordinates
+void viv_output_damage_layout_coords_box(struct viv_output *output, struct wlr_box *box);
+
+/// Damage the given region, expected to be unscaled an in output-layout coordinates
+void viv_output_damage_layout_coords_region(struct viv_output *output, pixman_region32_t *damage);
+
 /// Mark that whatever workspace is active will need its layout function applying
 void viv_output_mark_for_relayout(struct viv_output *output);
 #endif

--- a/include/viv_output.h
+++ b/include/viv_output.h
@@ -23,4 +23,10 @@ void viv_output_init(struct viv_output *output, struct viv_server *server, struc
 /// Apply the layout function of the current workspace, but only if the output or current
 /// workspace need layouting
 void viv_output_do_layout_if_necessary(struct viv_output *output);
+
+/// Mark the whole output as damaged
+void viv_output_damage(struct viv_output *output);
+
+/// Mark that whatever workspace is active will need its layout function applying
+void viv_output_mark_for_relayout(struct viv_output *output);
 #endif

--- a/include/viv_render.h
+++ b/include/viv_render.h
@@ -3,7 +3,7 @@
 
 #include "viv_types.h"
 
-void viv_render_view(struct wlr_renderer *renderer, struct viv_view *view, struct viv_output *output);
+void viv_render_view(struct wlr_renderer *renderer, struct viv_view *view, struct viv_output *output, pixman_region32_t *damage);
 
 void viv_render_layer_view(struct wlr_renderer *renderer, struct viv_layer_view *layer_view, struct viv_output *output);
 

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -47,8 +47,6 @@ struct viv_server {
 	struct wlr_xdg_shell *xdg_shell;
 	struct wl_listener new_xdg_surface;
 
-    struct wl_listener surface_commit;
-
 #ifdef XWAYLAND
     struct wlr_xwayland *xwayland_shell;
     xcb_atom_t window_type_atoms[WINDOW_TYPE_ATOM_MAX];
@@ -165,7 +163,7 @@ struct viv_layer_view {
 
     struct wl_list output_link;
 
-    uint32_t x, y;
+    int x, y;
 };
 
 enum viv_view_type {
@@ -190,17 +188,11 @@ struct viv_view_implementation {
 };
 
 struct viv_xdg_popup {
-    struct viv_view *view;
     struct wlr_xdg_popup *wlr_popup;
+    struct viv_server *server;
 
-    struct wl_listener surface_commit;
-    struct wl_listener surface_unmap;
-    struct wl_listener destroy;
-};
-
-struct viv_layer_popup {
-    struct viv_view *view;
-    struct wlr_xdg_popup *wlr_popup;
+    int *lx;  // pointer to x of parent view/layer-view in layout coords
+    int *ly;  // pointer to y of parent view/layer-view in layout coords
 
     struct wl_listener surface_commit;
     struct wl_listener surface_unmap;
@@ -326,7 +318,7 @@ struct viv_config {
     bool debug_mark_views_by_shell;
     bool debug_mark_active_output;
     bool debug_mark_frame_draws;
-    bool debug_draw_only_damaged_regions;
+    bool debug_mark_undamaged_regions;
 };
 
 

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -189,6 +189,7 @@ struct viv_view_implementation {
 
 struct viv_xdg_popup {
     struct wlr_xdg_popup *wlr_popup;
+    struct viv_xdg_popup *parent_popup;
     struct viv_server *server;
 
     int *lx;  // pointer to x of parent view/layer-view in layout coords
@@ -197,6 +198,7 @@ struct viv_xdg_popup {
     struct wl_listener surface_commit;
     struct wl_listener surface_unmap;
     struct wl_listener destroy;
+    struct wl_listener new_popup;
 };
 
 struct viv_view {

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -15,6 +15,12 @@
 #include "viv_xwayland_types.h"
 #endif
 
+enum viv_damage_tracking_mode {
+    VIV_DAMAGE_TRACKING_NONE,  // every frame is fully re-rendered
+    VIV_DAMAGE_TRACKING_FRAME,   // any damage triggers a full frame render
+    VIV_DAMAGE_TRACKING_FULL,  // only damaged regions are rendered
+};
+
 enum viv_cursor_mode {
 	VIV_CURSOR_PASSTHROUGH,  /// Pass through cursor data to views
 	VIV_CURSOR_MOVE,  /// A view is being moved
@@ -30,6 +36,7 @@ enum cursor_buttons {
 struct viv_output;  // Forward declare for use by viv_server
 
 struct viv_server {
+    char *user_provided_config_filen;
     struct viv_config *config;
 
 	struct wl_display *wl_display;
@@ -119,6 +126,8 @@ struct viv_output {
 
     bool needs_layout;
     struct viv_workspace *current_workspace;
+
+    uint32_t frame_draw_count;  // only used by debug options
 
     struct wl_list layer_views;
     struct {
@@ -312,10 +321,12 @@ struct viv_config {
 
     struct viv_libinput_config *libinput_configs;
 
+    enum viv_damage_tracking_mode damage_tracking_mode;
+
     bool debug_mark_views_by_shell;
     bool debug_mark_active_output;
     bool debug_mark_frame_draws;
-    bool debug_no_damage_tracking;
+    bool debug_draw_only_damaged_regions;
 };
 
 

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -40,6 +40,8 @@ struct viv_server {
 	struct wlr_xdg_shell *xdg_shell;
 	struct wl_listener new_xdg_surface;
 
+    struct wl_listener surface_commit;
+
 #ifdef XWAYLAND
     struct wlr_xwayland *xwayland_shell;
     xcb_atom_t window_type_atoms[WINDOW_TYPE_ATOM_MAX];
@@ -113,6 +115,8 @@ struct viv_output {
 	struct wlr_output *wlr_output;
 	struct wl_listener frame;
 
+    struct wlr_output_damage *damage;
+
     bool needs_layout;
     struct viv_workspace *current_workspace;
 
@@ -147,6 +151,7 @@ struct viv_layer_view {
     struct wl_listener unmap;
     struct wl_listener destroy;
     struct wl_listener new_popup;
+    struct wl_listener surface_commit;
     bool mapped;
 
     struct wl_list output_link;
@@ -173,6 +178,24 @@ struct viv_view_implementation {
     void (*close)(struct viv_view *view);
     bool (*is_at)(struct viv_view *view, double lx, double ly, struct wlr_surface **surface, double *sx, double *sy);
     bool (*oversized)(struct viv_view *view);
+};
+
+struct viv_xdg_popup {
+    struct viv_view *view;
+    struct wlr_xdg_popup *wlr_popup;
+
+    struct wl_listener surface_commit;
+    struct wl_listener surface_unmap;
+    struct wl_listener destroy;
+};
+
+struct viv_layer_popup {
+    struct viv_view *view;
+    struct wlr_xdg_popup *wlr_popup;
+
+    struct wl_listener surface_commit;
+    struct wl_listener surface_unmap;
+    struct wl_listener destroy;
 };
 
 struct viv_view {
@@ -204,6 +227,7 @@ struct viv_view {
 
     // Surface bindings
     struct wl_listener surface_commit;
+    struct wl_listener new_xdg_popup;
 
     // Target positions, where the layout is trying to place the view
     int target_x, target_y;
@@ -290,6 +314,8 @@ struct viv_config {
 
     bool debug_mark_views_by_shell;
     bool debug_mark_active_output;
+    bool debug_mark_frame_draws;
+    bool debug_no_damage_tracking;
 };
 
 

--- a/include/viv_view.h
+++ b/include/viv_view.h
@@ -43,6 +43,9 @@ void viv_view_get_string_identifier(struct viv_view *view, char *buffer, size_t 
 /// True if the surface geometry size exceeds that of the target draw region, else false
 bool viv_view_oversized(struct viv_view *view);
 
+/// Mark the view as damaged on every output
+void viv_view_damage(struct viv_view *view);
+
 /// Make the given view the active view within its workspace
 void viv_view_make_active(struct viv_view *view);
 

--- a/include/viv_wlr_surface_tree.h
+++ b/include/viv_wlr_surface_tree.h
@@ -1,0 +1,38 @@
+#ifndef VIV_WLR_SURFACE_TREE_H
+#define VIV_WLR_SURFACE_TREE_H
+
+#include "viv_types.h"
+
+struct viv_surface_tree_node {
+    struct viv_server *server;
+    struct wlr_surface *wlr_surface;
+
+    struct wl_listener new_subsurface;
+    struct wl_listener commit;
+    struct wl_listener destroy;
+
+    struct viv_surface_tree_node *parent;
+    struct viv_wlr_subsurface *subsurface;
+    struct wl_list parent_link;
+
+    void (*apply_global_offset)(void *, int *, int *);
+    void *global_offset_data;
+};
+
+struct viv_wlr_subsurface {
+    struct viv_server *server;
+    struct wlr_subsurface *wlr_subsurface;
+    struct viv_surface_tree_node *parent;
+
+    struct wl_listener map;
+    struct wl_listener unmap;
+    struct wl_listener destroy;
+};
+
+
+// Create a surface tree from the input surface. The surface tree will automatically wrap
+// all of the subsurfaces (existing or later-created) and handle all surface commit
+// events.  Commit events will be used to damage every output, with offsets calculated
+// including the global offset passed here.
+struct viv_surface_tree_node *viv_surface_tree_root_create(struct viv_server *server, struct wlr_surface *surface, void (*apply_global_offset)(void *, int *, int *), void *global_offset_data);
+#endif

--- a/include/viv_workspace.h
+++ b/include/viv_workspace.h
@@ -42,5 +42,12 @@ uint32_t viv_workspace_num_tiled_views(struct viv_workspace *workspace);
 /// link will be reused without checking.
 void viv_workspace_add_view(struct viv_workspace *workspace, struct viv_view *view);
 
+/// Mark all views in the workspace as damaged
+void viv_workspace_damage_views(struct viv_workspace *workspace);
+
+/// Mark that the workspace needs a layout - this works by damaging it
+/// then, after the next draw, actually applying the new layout
+// TODO: Should we just layout straight away now?
+void viv_workspace_mark_for_relayout(struct viv_workspace *workspace);
 
 #endif

--- a/include/viv_xdg_popup.h
+++ b/include/viv_xdg_popup.h
@@ -1,0 +1,8 @@
+#ifndef VIV_XDG_POPUP_H
+#define VIV_XDG_POPUP_H
+
+#include "viv_types.h"
+
+void viv_xdg_popup_init(struct viv_xdg_popup *popup, struct wlr_xdg_popup *wlr_popup);
+
+#endif

--- a/meson.build
+++ b/meson.build
@@ -52,6 +52,8 @@ libinput_dep = dependency('libinput')
 xcb_dep = dependency('xcb', required: get_option('xwayland'))
 pixman_dep = dependency('pixman-1')
 
+math_dep = cc.find_library('m')
+
 includes = [
   include_directories('include'),
   include_directories('protocols'),

--- a/meson.build
+++ b/meson.build
@@ -50,6 +50,7 @@ wayland_protocols_dep = dependency('wayland-protocols')
 xkbcommon_dep = dependency('xkbcommon')
 libinput_dep = dependency('libinput')
 xcb_dep = dependency('xcb', required: get_option('xwayland'))
+pixman_dep = dependency('pixman-1')
 
 includes = [
   include_directories('include'),

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,7 @@ viv_sources = [
   'viv_bar.c',
   'viv_cli.c',
   'viv_cursor.c',
+  'viv_damage.c',
   'viv_input.c',
   'viv_ipc.c',
   'viv_layout.c',
@@ -16,6 +17,7 @@ viv_sources = [
   'viv_view.c',
   'viv_wl_list_utils.c',
   'viv_workspace.c',
+  'viv_xdg_popup.c',
   'viv_xdg_shell.c',
 ]
 
@@ -35,6 +37,7 @@ viv_deps = [
     tomlc99_dep,
     xcb_dep,
     pixman_dep,
+    math_dep,
 ]
 
 executable(

--- a/src/meson.build
+++ b/src/meson.build
@@ -34,6 +34,7 @@ viv_deps = [
     layer_shell_protocol_dep,
     tomlc99_dep,
     xcb_dep,
+    pixman_dep,
 ]
 
 executable(

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ viv_sources = [
   'viv_toml_config.c',
   'viv_view.c',
   'viv_wl_list_utils.c',
+  'viv_wlr_surface_tree.c',
   'viv_workspace.c',
   'viv_xdg_popup.c',
   'viv_xdg_shell.c',

--- a/src/viv_cli.c
+++ b/src/viv_cli.c
@@ -110,6 +110,8 @@ struct viv_args viv_cli_parse_args(int argc, char *argv[]) {
             should_exit = handle_help(&parsed_args);
             break;
         case OPTION_PARSE_FAILURE:
+            // In this case getopt_long has already printed an error message so we don't
+            // need to add anything
             should_exit = true;
             break;
         default:

--- a/src/viv_cursor.c
+++ b/src/viv_cursor.c
@@ -12,10 +12,14 @@
 
 static void process_cursor_move_view(struct viv_server *server, uint32_t time) {
     UNUSED(time);
-    int old_x = server->grab_state.view->x;
-    int old_y = server->grab_state.view->y;
 
     struct viv_view *view = server->grab_state.view;
+
+    int old_x = view->x; //server->grab_state.view->x;
+    int old_y = view->y; //server->grab_state.view->y;
+
+    // Damage before moving
+    viv_view_damage(view);
 
 	/* Move the grabbed view to the new position. */
 	view->x = server->cursor->x - server->grab_state.x;
@@ -31,6 +35,9 @@ static void process_cursor_move_view(struct viv_server *server, uint32_t time) {
     if (output_at_point != view->workspace->output) {
         viv_view_shift_to_workspace(view, output_at_point->current_workspace);
     }
+
+    // Damage after moving
+    viv_view_damage(view);
 }
 
 static void process_cursor_resize_view(struct viv_server *server, uint32_t time) {
@@ -39,6 +46,9 @@ static void process_cursor_resize_view(struct viv_server *server, uint32_t time)
     // tinywl, we should wait for a buffer at the new size before
     // committing movement
 	struct viv_view *view = server->grab_state.view;
+
+    viv_view_damage(view);
+
 	double border_x = server->cursor->x - server->grab_state.x;
 	double border_y = server->cursor->y - server->grab_state.y;
 	int new_left = server->grab_state.geobox.x;
@@ -69,10 +79,8 @@ static void process_cursor_resize_view(struct viv_server *server, uint32_t time)
 		}
 	}
 
-	struct wlr_box geo_box;
-    viv_view_get_geometry(view, &geo_box);
-	view->x = new_left - geo_box.x;
-	view->y = new_top - geo_box.y;
+	view->x = new_left;
+	view->y = new_top;
 
 	int new_width = new_right - new_left;
 	int new_height = new_bottom - new_top;
@@ -82,6 +90,8 @@ static void process_cursor_resize_view(struct viv_server *server, uint32_t time)
     view->target_y = new_top;
     view->target_width = new_width;
     view->target_height = new_height;
+
+    viv_view_damage(view);
 }
 
 static bool layer_view_wants_keyboard_focus(struct viv_layer_view *layer_view) {

--- a/src/viv_cursor.c
+++ b/src/viv_cursor.c
@@ -15,8 +15,8 @@ static void process_cursor_move_view(struct viv_server *server, uint32_t time) {
 
     struct viv_view *view = server->grab_state.view;
 
-    int old_x = view->x; //server->grab_state.view->x;
-    int old_y = view->y; //server->grab_state.view->y;
+    int old_x = view->x;
+    int old_y = view->y;
 
     // Damage before moving
     viv_view_damage(view);

--- a/src/viv_damage.c
+++ b/src/viv_damage.c
@@ -1,0 +1,24 @@
+
+#include <pixman-1/pixman.h>
+#include <wayland-util.h>
+#include <wlr/types/wlr_output_damage.h>
+
+#include "viv_output.h"
+#include "viv_types.h"
+
+
+/// Apply the damage from this surface to every output
+void viv_damage_surface(struct viv_server *server, struct wlr_surface *surface, int lx, int ly) {
+    pixman_region32_t damage;
+    pixman_region32_init(&damage);
+    wlr_surface_get_effective_damage(surface, &damage);
+
+    pixman_region32_translate(&damage, lx, ly);
+
+    struct viv_output *output;
+    wl_list_for_each(output, &server->outputs, link) {
+        viv_output_damage_layout_coords_region(output, &damage);
+    }
+
+    pixman_region32_fini(&damage);
+}

--- a/src/viv_layer_view.c
+++ b/src/viv_layer_view.c
@@ -1,4 +1,6 @@
+#include <pixman-1/pixman.h>
 #include <wayland-util.h>
+#include <wlr/types/wlr_output_damage.h>
 
 #include "wlr-layer-shell-unstable-v1-protocol.h"
 
@@ -8,6 +10,24 @@
 #include "viv_types.h"
 #include "viv_view.h"
 
+static void handle_layer_surface_commit(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct viv_layer_view *layer_view = wl_container_of(listener, layer_view, surface_commit);
+    struct wlr_surface *surface = layer_view->layer_surface->surface;
+
+    pixman_region32_t damage;
+    pixman_region32_init(&damage);
+    wlr_surface_get_effective_damage(surface, &damage);
+
+    pixman_region32_translate(&damage, layer_view->x, layer_view->y);
+
+    struct viv_output *viv_output = wl_container_of(layer_view->server->outputs.next, viv_output, link);
+    struct wlr_output_damage *output_damage = viv_output->damage;
+    wlr_output_damage_add(output_damage, &damage);
+
+    pixman_region32_fini(&damage);
+}
+
 static void layer_surface_map(struct wl_listener *listener, void *data) {
     UNUSED(data);
     wlr_log(WLR_DEBUG, "Mapping a layer surface");
@@ -15,7 +35,7 @@ static void layer_surface_map(struct wl_listener *listener, void *data) {
 	struct viv_layer_view *layer_view = wl_container_of(listener, layer_view, map);
 	layer_view->mapped = true;
 
-    layer_view->output->needs_layout = true;
+    viv_output_mark_for_relayout(layer_view->output);
 
     if (layer_view->layer_surface->current.keyboard_interactive) {
         viv_surface_focus(layer_view->server, layer_view->layer_surface->surface);
@@ -28,7 +48,7 @@ static void layer_surface_unmap(struct wl_listener *listener, void *data) {
 	struct viv_layer_view *layer_view = wl_container_of(listener, layer_view, unmap);
 	layer_view->mapped = false;
 
-    layer_view->output->needs_layout = true;
+    viv_output_mark_for_relayout(layer_view->output);
 
 	struct wlr_seat *seat = layer_view->output->server->seat;
 	struct wlr_surface *prev_surface = seat->keyboard_state.focused_surface;
@@ -52,15 +72,73 @@ static void layer_surface_destroy(struct wl_listener *listener, void *data) {
 
 	wl_list_remove(&layer_view->output_link);
 
-    layer_view->output->needs_layout = true;
+    viv_output_mark_for_relayout(layer_view->output);
 
 	free(layer_view);
 }
 
-static void layer_surface_new_popup(struct wl_listener *listener, void *data) {
-    UNUSED(listener);
+static void handle_popup_surface_commit(struct wl_listener *listener, void *data) {
     UNUSED(data);
-    wlr_log(WLR_ERROR, "New layer surface popup event not yet handled");
+    struct viv_xdg_popup *popup = wl_container_of(listener, popup, surface_commit);
+    struct viv_view *view = popup->view;
+    struct wlr_surface *surface = popup->wlr_popup->base->surface;
+
+    pixman_region32_t damage;
+    pixman_region32_init(&damage);
+    wlr_surface_get_effective_damage(surface, &damage);
+
+    pixman_region32_translate(&damage, view->x + popup->wlr_popup->geometry.x, view->y + popup->wlr_popup->geometry.y);
+
+    struct viv_output *viv_output = wl_container_of(view->server->outputs.next, viv_output, link);
+    struct wlr_output_damage *output_damage = viv_output->damage;
+    wlr_output_damage_add(output_damage, &damage);
+
+    wlr_log(WLR_DEBUG, "popup for view %s commit", view->xdg_surface->toplevel->app_id);
+
+    pixman_region32_fini(&damage);
+}
+
+static void handle_popup_surface_unmap(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct viv_xdg_popup *popup = wl_container_of(listener, popup, surface_unmap);
+    struct viv_view *view = popup->view;
+
+    struct wlr_box geo_box = {
+        .x = view->x + popup->wlr_popup->geometry.x,
+        .y = view->y + popup->wlr_popup->geometry.y,
+        .width = popup->wlr_popup->geometry.width,
+        .height = popup->wlr_popup->geometry.height,
+    };
+
+    struct viv_output *output;
+    wl_list_for_each(output, &view->server->outputs, link) {
+        wlr_output_damage_add_box(output->damage, &geo_box);
+    }
+}
+
+static void handle_popup_surface_destroy(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct viv_xdg_popup *popup = wl_container_of(listener, popup, destroy);
+    wlr_log(WLR_INFO, "Popup being destroyed");
+    free(popup);
+}
+
+static void layer_surface_new_popup(struct wl_listener *listener, void *data) {
+    struct viv_view *view = wl_container_of(listener, view, new_xdg_popup);
+	struct wlr_xdg_popup *wlr_popup = data;
+
+    struct viv_xdg_popup *popup = calloc(1, sizeof(struct viv_xdg_popup));
+    popup->view = view;
+    popup->wlr_popup = wlr_popup;
+
+    popup->surface_commit.notify = handle_popup_surface_commit;
+    wl_signal_add(&wlr_popup->base->surface->events.commit, &popup->surface_commit);
+
+    popup->surface_unmap.notify = handle_popup_surface_unmap;
+    wl_signal_add(&wlr_popup->base->events.unmap, &popup->surface_unmap);
+
+    popup->destroy.notify = handle_popup_surface_destroy;
+    wl_signal_add(&wlr_popup->base->surface->events.destroy, &popup->destroy);
 }
 
 void viv_layer_view_init(struct viv_layer_view *layer_view, struct viv_server *server, struct wlr_layer_surface_v1 *layer_surface) {
@@ -77,6 +155,9 @@ void viv_layer_view_init(struct viv_layer_view *layer_view, struct viv_server *s
 	layer_view->new_popup.notify = layer_surface_new_popup;
 	wl_signal_add(&layer_surface->events.new_popup, &layer_view->new_popup);
     UNUSED(layer_surface_new_popup);
+
+    layer_view->surface_commit.notify = handle_layer_surface_commit;
+    wl_signal_add(&layer_surface->surface->events.commit, &layer_view->surface_commit);
 
     struct viv_output *output = viv_output_of_wlr_output(server, layer_surface->output);
     wl_list_insert(&output->layer_views, &layer_view->output_link);

--- a/src/viv_mappable_functions.c
+++ b/src/viv_mappable_functions.c
@@ -261,3 +261,12 @@ void viv_mappable_debug_swap_buffers(struct viv_workspace *workspace, union viv_
     UNUSED(payload);
     wlr_output_commit(workspace->output->wlr_output);
 }
+
+void viv_mappable_debug_toggle_show_undamaged_regions(struct viv_workspace *workspace, union viv_mappable_payload payload) {
+    UNUSED(payload);
+    workspace->server->config->debug_mark_undamaged_regions = !workspace->server->config->debug_mark_undamaged_regions;
+    struct viv_output *output;
+    wl_list_for_each(output, &workspace->server->outputs, link) {
+        viv_output_damage(output);
+    }
+}

--- a/src/viv_mappable_functions.c
+++ b/src/viv_mappable_functions.c
@@ -5,6 +5,7 @@
 #include <unistd.h>
 
 #include <wayland-server-core.h>
+#include <wayland-util.h>
 #include <wlr/types/wlr_output_layout.h>
 #include <wlr/util/log.h>
 
@@ -99,6 +100,8 @@ void viv_mappable_tile_window(struct viv_workspace *workspace, union viv_mappabl
         return;
     }
 
+    viv_view_damage(view);
+
     bool any_not_floating = false;
     struct viv_view *non_floating_view;
     wl_list_for_each(non_floating_view, &workspace->views, workspace_link) {
@@ -118,6 +121,8 @@ void viv_mappable_tile_window(struct viv_workspace *workspace, union viv_mappabl
         // Move to the end of the views (as all are floating)
         wl_list_insert(workspace->views.prev, &view->workspace_link);
     }
+
+    viv_workspace_mark_for_relayout(workspace);
 }
 
 void viv_mappable_next_layout(struct viv_workspace *workspace, union viv_mappable_payload payload) {
@@ -240,4 +245,19 @@ void viv_mappable_reload_config(struct viv_workspace *workspace, union viv_mappa
     UNUSED(payload);
     struct viv_server *server = workspace->server;
     viv_server_reload_config(server);
+}
+
+void viv_mappable_debug_damage_all(struct viv_workspace *workspace, union viv_mappable_payload payload) {
+    UNUSED(payload);
+    struct viv_server *server = workspace->server;
+
+    struct viv_output *output;
+    wl_list_for_each(output, &server->outputs, link) {
+        viv_output_damage(output);
+    }
+}
+
+void viv_mappable_debug_swap_buffers(struct viv_workspace *workspace, union viv_mappable_payload payload) {
+    UNUSED(payload);
+    wlr_output_commit(workspace->output->wlr_output);
 }

--- a/src/viv_render.c
+++ b/src/viv_render.c
@@ -21,20 +21,21 @@
  * frame handler to the per-surface render function. */
 // TODO: should this be internal to viv_render.c?
 struct viv_render_data {
-	struct wlr_output *output;
-	struct wlr_renderer *renderer;
-	struct viv_view *view;
-	struct timespec *when;
+    struct wlr_output *output;
+    struct wlr_renderer *renderer;
+    struct viv_view *view;
+    struct timespec *when;
     bool limit_render_count;
     uint32_t max_surfaces_to_render;
     int sx;
     int sy;
     pixman_region32_t *damage;
+    pixman_region32_t *surface_bounds;  // the actual bounds on the surface outside which it cannot draw
 };
 
 static void render_surface(struct wlr_surface *surface, int sx, int sy, void *data) {
-	/* This function is called for every surface that needs to be rendered. */
-	struct viv_render_data *rdata = data;
+    /* This function is called for every surface that needs to be rendered. */
+    struct viv_render_data *rdata = data;
 
     sx += rdata->sx;
     sy += rdata->sy;
@@ -44,123 +45,92 @@ static void render_surface(struct wlr_surface *surface, int sx, int sy, void *da
         return;
     }
 
-	struct viv_view *view = rdata->view;
-	struct wlr_output *output = rdata->output;
+    struct viv_view *view = rdata->view;
+    struct wlr_output *output = rdata->output;
     struct wlr_renderer *renderer = rdata->renderer;
     pixman_region32_t *damage = rdata->damage;
 
-	struct wlr_texture *texture = wlr_surface_get_texture(surface);
-	if (texture == NULL) {
-		return;
-	}
+    // Generate a damaged area worth drawing from the intersection of the supplied surface
+    // bounds (if any) and the damaged region
+    pixman_region32_t applied_surface_bounds;
+    pixman_region32_init(&applied_surface_bounds);
+    pixman_region32_union(&applied_surface_bounds, &applied_surface_bounds, damage);
+    if (rdata->surface_bounds) {
+        pixman_region32_intersect(&applied_surface_bounds, &applied_surface_bounds, rdata->surface_bounds);
+    }
+
+    struct wlr_texture *texture = wlr_surface_get_texture(surface);
+    if (texture == NULL) {
+        return;
+    }
 
     // Translate to output-local coordinates
-	double ox = 0, oy = 0;
-	wlr_output_layout_output_coords(
-			view->server->output_layout, output, &ox, &oy);
-	ox += view->x + sx;
+    double ox = 0, oy = 0;
+    wlr_output_layout_output_coords(
+            view->server->output_layout, output, &ox, &oy);
+    ox += view->x + sx;
     oy += view->y + sy;
 
     // Apply output scale factor
     // TODO: this needs more work elsewhere to actually work
-	struct wlr_box box = {
-		.x = ox * output->scale,
-		.y = oy * output->scale,
-		.width = surface->current.width * output->scale,
-		.height = surface->current.height * output->scale,
-	};
+    struct wlr_box box = {
+        .x = ox * output->scale,
+        .y = oy * output->scale,
+        .width = surface->current.width * output->scale,
+        .height = surface->current.height * output->scale,
+    };
 
-	float matrix[9];
-	enum wl_output_transform transform =
-		wlr_output_transform_invert(surface->current.transform);
-	wlr_matrix_project_box(matrix, &box, transform, 0,
-		output->transform_matrix);
+    float matrix[9];
+    enum wl_output_transform transform =
+        wlr_output_transform_invert(surface->current.transform);
+    wlr_matrix_project_box(matrix, &box, transform, 0,
+        output->transform_matrix);
 
-    int num_rects;
-	pixman_box32_t *rects = pixman_region32_rectangles(damage, &num_rects);
-    for (int i = 0; i < num_rects; i++) {
-        pixman_box32_t rect = rects[i];
-        struct wlr_box box = {
-            .x = rect.x1,
-            .y = rect.y1,
-            .width = rect.x2 - rect.x1,
-            .height = rect.y2 - rect.y1,
-        };
-        int output_width, output_height;
-        wlr_output_transformed_resolution(output, &output_width, &output_height);
-        wlr_box_transform(&box, &box, transform, output_width, output_height);
-        wlr_renderer_scissor(renderer, &box);
+    if (pixman_region32_not_empty(&applied_surface_bounds)) {
+        int num_rects;
+        pixman_box32_t *rects = pixman_region32_rectangles(&applied_surface_bounds, &num_rects);
+        for (int i = 0; i < num_rects; i++) {
+            pixman_box32_t rect = rects[i];
+            struct wlr_box box = {
+                .x = rect.x1,
+                .y = rect.y1,
+                .width = rect.x2 - rect.x1,
+                .height = rect.y2 - rect.y1,
+            };
+            int output_width, output_height;
+            wlr_output_transformed_resolution(output, &output_width, &output_height);
+            wlr_box_transform(&box, &box, transform, output_width, output_height);
+            wlr_renderer_scissor(renderer, &box);
 
-        /* This takes our matrix, the texture, and an alpha, and performs the actual
-        * rendering on the GPU. */
-        wlr_render_texture_with_matrix(rdata->renderer, texture, matrix, 1);
+            /* This takes our matrix, the texture, and an alpha, and performs the actual
+            * rendering on the GPU. */
+            wlr_render_texture_with_matrix(rdata->renderer, texture, matrix, 1);
+        }
     }
 
-	/* This lets the client know that we've displayed that frame and it can
-	 * prepare another one now if it likes. */
+    /* This lets the client know that we've displayed that frame and it can
+     * prepare another one now if it likes. */
     // TODO: Should be wlr_presentation_surface_sampled_on_output?
-	wlr_surface_send_frame_done(surface, rdata->when);
+    wlr_surface_send_frame_done(surface, rdata->when);
 
     if (rdata->limit_render_count) {
         rdata->max_surfaces_to_render--;
     }
+
+    pixman_region32_fini(&applied_surface_bounds);
 }
 
 static void popup_render_surface(struct wlr_surface *surface, int sx, int sy, void *data) {
     // TODO: wlroots 0.13 probably iterates over each popup surface autoamtically
-	struct viv_render_data *rdata = data;
+    struct viv_render_data *rdata = data;
     rdata->sx = sx;
     rdata->sy = sy;
     wlr_surface_for_each_surface(surface, render_surface, rdata);
 }
 
-static void render_rect_borders(struct wlr_renderer *renderer, struct viv_server *server, struct viv_output *output, double x, double y, int width, int height) {
-    double lx = 0, ly = 0;
-	wlr_output_layout_output_coords(server->output_layout, output->wlr_output, &lx, &ly);
-    x += lx;
-    y += ly;
-    float colour[4] = {0.1, 0.3, 1.0, 0.0};
-
-    int line_width = 3;
-
-    // TODO: account for scale factor
-
-    struct wlr_box box;
-
-    // bottom
-    box.x = x;
-    box.y = y;
-    box.width = width;
-    box.height = line_width;
-    wlr_render_rect(renderer, &box, colour, output->wlr_output->transform_matrix);
-
-    // top
-    box.x = x;
-    box.y = y + height - line_width;
-    box.width = width;
-    box.height = line_width;
-    wlr_render_rect(renderer, &box, colour, output->wlr_output->transform_matrix);
-
-    // left
-    box.x = x;
-    box.y = y;
-    box.width = line_width;
-    box.height = height;
-    wlr_render_rect(renderer, &box, colour, output->wlr_output->transform_matrix);
-
-    // right
-    box.x = x + width - line_width;
-    box.y = y;
-    box.width = line_width;
-    box.height = height;
-    wlr_render_rect(renderer, &box, colour, output->wlr_output->transform_matrix);
-
-}
-
 static void render_rect(struct wlr_box *box, struct viv_output *output, pixman_region32_t *damage, float colour[static 4]) {
-    UNUSED(damage);
     struct wlr_output *wlr_output = output->wlr_output;
-	struct wlr_renderer *renderer = output->server->renderer;
+    struct wlr_renderer *renderer = output->server->renderer;
 
     // TODO: Need to translate box to output coords - -= output->lx etc.
 
@@ -195,8 +165,8 @@ static void render_borders(struct viv_view *view, struct viv_output *output, pix
     int gap_width = server->config->gap_width;
 
     double x = 0, y = 0;
-	wlr_output_layout_output_coords(server->output_layout, output->wlr_output, &x, &y);
-	x += view->target_x + gap_width;
+    wlr_output_layout_output_coords(server->output_layout, output->wlr_output, &x, &y);
+    x += view->target_x + gap_width;
     y += view->target_y + gap_width;
     int width = MAX(1, view->target_width - 2 * gap_width);
     int height = MAX(1, view->target_height - 2 * gap_width);
@@ -246,20 +216,8 @@ static void viv_render_xdg_view(struct wlr_renderer *renderer, struct viv_view *
         return;
     }
 
-	struct timespec now;
-	clock_gettime(CLOCK_MONOTONIC, &now);
-
-    struct viv_render_data rdata = {
-        .output = output->wlr_output,
-        .view = view,
-        .renderer = renderer,
-        .when = &now,
-        .limit_render_count = true,
-        .max_surfaces_to_render = 1 + wl_list_length(&view->xdg_surface->surface->subsurfaces),
-        .sx = 0,
-        .sy = 0,
-        .damage = damage,
-    };
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
 
     // Note this renders both the toplevel and any popups
     struct wlr_box actual_geometry = { 0 };
@@ -271,23 +229,32 @@ static void viv_render_xdg_view(struct wlr_renderer *renderer, struct viv_view *
     };
     wlr_xdg_surface_get_geometry(view->xdg_surface, &actual_geometry);
 
-    bool surface_exceeds_bounds = viv_view_oversized(view);
+    viv_output_layout_coords_box_to_output_coords(output, &target_geometry);
 
-    // Render only the main surface
-    if (surface_exceeds_bounds) {
-        // Only scissor if the view's surface exceeds its bounds, to save a tiny bit of time
+    pixman_region32_t surface_bounds;
+    pixman_region32_init(&surface_bounds);
+    pixman_region32_copy(&surface_bounds, damage);
 
-        double ox = 0, oy = 0;
-        wlr_output_layout_output_coords(view->server->output_layout, output->wlr_output, &ox, &oy);
-        target_geometry.x += ox;
-        target_geometry.y += oy;
-
-        wlr_renderer_scissor(renderer, &target_geometry);
+    bool apply_surface_bounds = (output->server->config->damage_tracking_mode == VIV_DAMAGE_TRACKING_FULL);
+    if (apply_surface_bounds) {
+        pixman_region32_intersect_rect(&surface_bounds, &surface_bounds, target_geometry.x, target_geometry.y, target_geometry.width, target_geometry.height);
     }
-    wlr_surface_for_each_surface(view->xdg_surface->surface, render_surface, &rdata);
 
-    // Always clear the scissoring so that we can draw borders anywhere
-    wlr_renderer_scissor(renderer, NULL);
+    struct viv_render_data rdata = {
+        .output = output->wlr_output,
+        .view = view,
+        .renderer = renderer,
+        .when = &now,
+        .limit_render_count = true,
+        .max_surfaces_to_render = 1 + wl_list_length(&view->xdg_surface->surface->subsurfaces),
+        .sx = 0,
+        .sy = 0,
+        .damage = damage,
+        .surface_bounds = apply_surface_bounds ? &surface_bounds : NULL,
+    };
+
+    // Render only the main surfaces (not popups)
+    wlr_surface_for_each_surface(view->xdg_surface->surface, render_surface, &rdata);
 
     // Then render the main surface's borders
     bool is_grabbed = ((output->server->cursor_mode != VIV_CURSOR_PASSTHROUGH) &&
@@ -301,6 +268,7 @@ static void viv_render_xdg_view(struct wlr_renderer *renderer, struct viv_view *
 
     // Then render any popups
     rdata.limit_render_count = false;
+    rdata.surface_bounds = NULL;  // popups can exceed the primary surface region
     wlr_xdg_surface_for_each_popup(view->xdg_surface, popup_render_surface, &rdata);
 
 #ifdef DEBUG
@@ -315,6 +283,8 @@ static void viv_render_xdg_view(struct wlr_renderer *renderer, struct viv_view *
         }
     }
 #endif
+
+    pixman_region32_fini(&surface_bounds);
 }
 
 #ifdef XWAYLAND
@@ -325,8 +295,19 @@ static void viv_render_xwayland_view(struct wlr_renderer *renderer, struct viv_v
         return;
     }
 
-	struct timespec now;
-	clock_gettime(CLOCK_MONOTONIC, &now);
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+
+    struct wlr_box target_geometry = {
+        .x = view->target_x,
+        .y = view->target_y,
+        .width = view->target_width,
+        .height = view->target_height
+    };
+
+    pixman_region32_t surface_bounds;
+    pixman_region32_init(&surface_bounds);
+    pixman_region32_union_rect(&surface_bounds, &surface_bounds, target_geometry.x, target_geometry.y, target_geometry.width, target_geometry.height);
 
     struct viv_render_data rdata = {
         .output = output->wlr_output,
@@ -337,32 +318,10 @@ static void viv_render_xwayland_view(struct wlr_renderer *renderer, struct viv_v
         .sx = 0,
         .sy = 0,
         .damage = damage,
+        .surface_bounds = &surface_bounds,
     };
 
-    struct wlr_box target_geometry = {
-        .x = view->target_x,
-        .y = view->target_y,
-        .width = view->target_width,
-        .height = view->target_height
-    };
-
-    bool surface_exceeds_bounds = viv_view_oversized(view);
-
-    // Render only the main surface
-    if (surface_exceeds_bounds) {
-        // Only scissor if the view's surface exceeds its bounds, to save a tiny bit of time
-
-        double ox = 0, oy = 0;
-        wlr_output_layout_output_coords(view->server->output_layout, output->wlr_output, &ox, &oy);
-        target_geometry.x += ox;
-        target_geometry.y += oy;
-
-        wlr_renderer_scissor(renderer, &target_geometry);
-    }
     wlr_surface_for_each_surface(viv_view_get_toplevel_surface(view), render_surface, &rdata);
-    if (surface_exceeds_bounds) {
-        wlr_renderer_scissor(renderer, NULL);
-    }
 
     // Then render the main surface's borders
     bool is_grabbed = ((output->server->cursor_mode != VIV_CURSOR_PASSTHROUGH) &&
@@ -374,6 +333,8 @@ static void viv_render_xwayland_view(struct wlr_renderer *renderer, struct viv_v
         (view->is_floating || !view->workspace->active_layout->no_borders)) {
         render_borders(view, output, damage, is_active);
     }
+
+    pixman_region32_fini(&surface_bounds);
 
 #ifdef DEBUG
     if (output->server->config->debug_mark_views_by_shell) {
@@ -412,8 +373,15 @@ void viv_render_layer_view(struct wlr_renderer *renderer, struct viv_layer_view 
         return;
     }
 
-	struct timespec now;
-	clock_gettime(CLOCK_MONOTONIC, &now);
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+
+    pixman_region32_t surface_bounds;
+    pixman_region32_init(&surface_bounds);
+    pixman_region32_union_rect(&surface_bounds, &surface_bounds,
+                               layer_view->x, layer_view->y,
+                               layer_view->layer_surface->current.actual_width,
+                               layer_view->layer_surface->current.actual_height);
 
     struct viv_view view = {.x = layer_view->x, .y = layer_view->y, .server = output->server};
     struct viv_render_data rdata = {
@@ -423,10 +391,15 @@ void viv_render_layer_view(struct wlr_renderer *renderer, struct viv_layer_view 
         .when = &now,
         .limit_render_count = false,
         .damage = damage,
+        .surface_bounds = &surface_bounds,
     };
 
     wlr_layer_surface_v1_for_each_surface(layer_view->layer_surface, render_surface, &rdata);
+
+    rdata.surface_bounds = NULL;  // surface bounds don't apply to popups
     wlr_layer_surface_v1_for_each_popup(layer_view->layer_surface, render_surface, &rdata);
+
+    pixman_region32_fini(&surface_bounds);
 }
 
 static bool viv_layer_is(struct viv_layer_view *layer_view, enum zwlr_layer_shell_v1_layer layer) {
@@ -441,10 +414,9 @@ void viv_render_output(struct wlr_renderer *renderer, struct viv_output *output)
     bool needs_frame;
     pixman_region32_init(&damage);
     bool attach_render_success = wlr_output_damage_attach_render(output->damage, &needs_frame, &damage);
-    /* wlr_log(WLR_INFO, "Return %d, needs frame: %d", attach_render_success, needs_frame); */
-	if (!attach_render_success) {
-		return;
-	}
+    if (!attach_render_success) {
+        return;
+    }
     if (!needs_frame) {
         wlr_output_rollback(output->wlr_output);
         return;
@@ -457,11 +429,11 @@ void viv_render_output(struct wlr_renderer *renderer, struct viv_output *output)
         pixman_region32_union_rect(&damage, &damage, 0, 0, width, height);
     }
 
-	/* The "effective" resolution can change if you rotate your outputs. */
-	int width, height;
-	wlr_output_effective_resolution(output->wlr_output, &width, &height);
-	/* Begin the renderer (calls glViewport and some other GL sanity checks) */
-	wlr_renderer_begin(renderer, width, height);
+    /* The "effective" resolution can change if you rotate your outputs. */
+    int width, height;
+    wlr_output_effective_resolution(output->wlr_output, &width, &height);
+    /* Begin the renderer (calls glViewport and some other GL sanity checks) */
+    wlr_renderer_begin(renderer, width, height);
 
     if (output->server->config->debug_mark_undamaged_regions) {
         // Clear the output with a solid colour, so that it is easy to
@@ -483,7 +455,7 @@ void viv_render_output(struct wlr_renderer *renderer, struct viv_output *output)
         wlr_renderer_clear(renderer, output->server->config->clear_colour);
     }
 
-	struct viv_view *view;
+    struct viv_view *view;
 
     struct viv_layer_view *layer_view;
 
@@ -500,12 +472,12 @@ void viv_render_output(struct wlr_renderer *renderer, struct viv_output *output)
     }
 
     // Begin rendering actual views: first render tiled windows
-	wl_list_for_each_reverse(view, &output->current_workspace->views, workspace_link) {
+    wl_list_for_each_reverse(view, &output->current_workspace->views, workspace_link) {
         if (view->is_floating || (view == output->current_workspace->active_view)) {
             continue;
         }
         viv_render_view(renderer, view, output, &damage);
-	}
+    }
 
     // Then render the active view if necessary
     if ((output->current_workspace->active_view != NULL) &&
@@ -530,12 +502,12 @@ void viv_render_output(struct wlr_renderer *renderer, struct viv_output *output)
     }
 
     // Finally render all floating views on this output (which may include the active view)
-	wl_list_for_each_reverse(view, &output->current_workspace->views, workspace_link) {
+    wl_list_for_each_reverse(view, &output->current_workspace->views, workspace_link) {
         if (!view->is_floating) {
             continue;
         }
         viv_render_view(renderer, view, output, &damage);
-	}
+    }
 
     // Render any layer surfaces that should go on top of views
     wl_list_for_each_reverse(layer_view, &output->layer_views, output_link) {
@@ -575,33 +547,33 @@ void viv_render_output(struct wlr_renderer *renderer, struct viv_output *output)
         };
         wlr_render_rect(renderer ,&output_marker_box, output_marker_colour, output->wlr_output->transform_matrix);
     }
-
-    UNUSED(render_rect_borders);
 #endif
 
     // Have wlroots render software cursors if necessary (does nothing
     // if hardware cursors available)
-	wlr_output_render_software_cursors(output->wlr_output, NULL);
+    wlr_output_render_software_cursors(output->wlr_output, NULL);
 
-	// Conclude rendering
-	wlr_renderer_end(renderer);
+    // Conclude rendering
+    wlr_renderer_end(renderer);
 
     // Calculate the frame damage before swapping the buffers
-	pixman_region32_t frame_damage;
-	pixman_region32_init(&frame_damage);
+    pixman_region32_t frame_damage;
+    pixman_region32_init(&frame_damage);
 
     // Fill in frame damage
     struct wlr_output *wlr_output = output->wlr_output;
-	int fwidth, fheight;
-	wlr_output_transformed_resolution(wlr_output, &fwidth, &fheight);
-	enum wl_output_transform transform = wlr_output_transform_invert(wlr_output->transform);
+    int fwidth, fheight;
+    wlr_output_transformed_resolution(wlr_output, &fwidth, &fheight);
+    enum wl_output_transform transform = wlr_output_transform_invert(wlr_output->transform);
     wlr_region_transform(&frame_damage, &output->damage->current, transform, fwidth, fheight);
 
     wlr_output_set_damage(output->wlr_output, &frame_damage);
-	pixman_region32_fini(&frame_damage);
+    pixman_region32_fini(&frame_damage);
+
+    pixman_region32_fini(&damage);
 
     // Swap the buffers
-	wlr_output_commit(output->wlr_output);
+    wlr_output_commit(output->wlr_output);
 
     struct viv_server *server = output->server;
     if (server->config->damage_tracking_mode == VIV_DAMAGE_TRACKING_NONE) {

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -789,7 +789,7 @@ void load_toml_config(struct viv_config *config, char *user_path) {
         wlr_log(WLR_DEBUG, "Resolved that default config path is \"%s\"", config_search_path);
         viv_toml_config_load(config_search_path, config, false);
     } else {
-        EXIT_WITH_MESSAGE("Could not construct config path for some reason - is $HOME not defined?");
+        EXIT_WITH_MESSAGE("Could not work out config path for some reason - is $HOME not defined?");
     }
 }
 

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -229,14 +229,12 @@ void viv_server_begin_interactive(struct viv_view *view, enum viv_cursor_mode mo
 	} else {
         struct wlr_box geo_box;
         viv_view_get_geometry(view, &geo_box);
-        double border_x = (view->x + geo_box.x) + ((edges & WLR_EDGE_RIGHT) ? geo_box.width : 0);
-        double border_y = (view->y + geo_box.y) + ((edges & WLR_EDGE_BOTTOM) ? geo_box.height : 0);
+        double border_x = (geo_box.x) + ((edges & WLR_EDGE_RIGHT) ? geo_box.width : 0);
+        double border_y = (geo_box.y) + ((edges & WLR_EDGE_BOTTOM) ? geo_box.height : 0);
         server->grab_state.x = server->cursor->x - border_x;
         server->grab_state.y = server->cursor->y - border_y;
 
         server->grab_state.geobox = geo_box;
-        server->grab_state.geobox.x += view->x;
-        server->grab_state.geobox.y += view->y;
 
         server->grab_state.resize_edges = edges;
 	}
@@ -414,7 +412,7 @@ static void server_new_layer_surface(struct wl_listener *listener, void *data) {
     viv_layer_view_init(layer_view, server, layer_surface);
 
     struct viv_output *output = viv_output_of_wlr_output(server, layer_surface->output);
-    output->needs_layout = true;
+    viv_output_mark_for_relayout(output);
 
     wlr_log(WLR_INFO, "New layer surface props: layer %d, anchor %d, exclusive %d, margin (%d, %d, %d, %d), desired size (%d, %d), actual size (%d, %d)", state->layer, state->anchor, state->exclusive_zone, state->margin.top, state->margin.right, state->margin.bottom, state->margin.left, state->desired_width, state->desired_height, state->actual_width, state->actual_height);
 }
@@ -798,7 +796,7 @@ void viv_server_reload_config(struct viv_server *server) {
 
     struct viv_output *output;
     wl_list_for_each(output, &server->outputs, link) {
-        output->needs_layout = true;
+        viv_output_mark_for_relayout(output);
     }
 
     // TODO: Reset workspaces and layouts according to new config

--- a/src/viv_toml_config.c
+++ b/src/viv_toml_config.c
@@ -609,7 +609,7 @@ void load_file_as_toml_config(FILE *fp, struct viv_config *config) {
     // [debug]
     parse_config_bool(root, "debug", "mark-views-by-shell", &config->debug_mark_views_by_shell);
     parse_config_bool(root, "debug", "mark-active-output", &config->debug_mark_active_output);
-    parse_config_bool(root, "debug", "draw-only-damaged-regions", &config->debug_draw_only_damaged_regions);
+    parse_config_bool(root, "debug", "mark-undamaged-regions", &config->debug_mark_undamaged_regions);
     parse_config_bool(root, "debug", "mark-frame-draws", &config->debug_mark_frame_draws);
     parse_config_string_map(root, "debug", "damage-tracking-mode", damage_tracking_mode_map,
                             &config->damage_tracking_mode);

--- a/src/viv_toml_config.c
+++ b/src/viv_toml_config.c
@@ -92,6 +92,13 @@ static struct string_map_pair scroll_method_map[] = {
     NULL_STRING_MAP_PAIR,
 };
 
+static struct string_map_pair damage_tracking_mode_map[] = {
+    {"none", VIV_DAMAGE_TRACKING_NONE},
+    {"frame", VIV_DAMAGE_TRACKING_FRAME},
+    {"full", VIV_DAMAGE_TRACKING_FULL},
+    NULL_STRING_MAP_PAIR,
+};
+
 static bool is_null_string_map_pair(struct string_map_pair *row) {
     return (strlen(row->key) == 0);
 }
@@ -602,6 +609,10 @@ void load_file_as_toml_config(FILE *fp, struct viv_config *config) {
     // [debug]
     parse_config_bool(root, "debug", "mark-views-by-shell", &config->debug_mark_views_by_shell);
     parse_config_bool(root, "debug", "mark-active-output", &config->debug_mark_active_output);
+    parse_config_bool(root, "debug", "draw-only-damaged-regions", &config->debug_draw_only_damaged_regions);
+    parse_config_bool(root, "debug", "mark-frame-draws", &config->debug_mark_frame_draws);
+    parse_config_string_map(root, "debug", "damage-tracking-mode", damage_tracking_mode_map,
+                            &config->damage_tracking_mode);
 
     // [[keybind]] list
     PARSE_CONFIG_ARRAY_VARIABLE_LENGTH(root, "keybind", struct viv_keybind, parse_keybind_table, TERMINATE_KEYBINDS_LIST(), &config->keybinds);
@@ -632,7 +643,7 @@ void viv_toml_config_load(char *path, struct viv_config *config, bool user_path)
             EXIT_WITH_FORMATTED_MESSAGE("Could not open user-specified config at \"%s\"", path);
         } else {
             // We didn't find the config in a default location, that's fine
-            wlr_log(WLR_INFO, "Config not found at path \"%s\", skipping config load", path);
+            wlr_log(WLR_INFO, "Config not found at default path \"%s\", skipping config load", path);
         }
     } else
     {

--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -36,6 +36,13 @@ void viv_view_focus(struct viv_view *view, struct wlr_surface *surface) {
     }
 	struct viv_server *server = view->server;
 
+    // Damage both previous and newly-active surface
+    // TODO: only damage the borders
+    if (view->workspace->active_view) {
+        viv_view_damage(view->workspace->active_view);
+    }
+    viv_view_damage(view);
+
 	/* Activate the new surface */
     view->workspace->active_view = view;
     viv_surface_focus(server, surface);
@@ -147,27 +154,19 @@ bool viv_view_oversized(struct viv_view *view) {
     return view->implementation->oversized(view);
 }
 
-/* /// Return the view bounding box in coordinates relative to the given output */
-/* static struct wlr_box viv_view_output_coords(struct viv_view *view, struct viv_output *output) { */
-/*     double lx, ly; */
-/*     wlr_output_layout_output_coords(view->server->output_layout, output->wlr_output, &lx, &ly); */
-
-/*     struct wlr_box geo_box = { */
-/*         .x = view->target_x - lx, */
-/*         .y = view->target_y - ly, */
-/*         .width = view->target_width, */
-/*         .height = view->target_height, */
-/*     }; */
-
-/*     return geo_box; */
-/* } */
-
 void viv_view_damage(struct viv_view *view) {
     struct viv_output *output;
+    struct wlr_box geo_box = { 0 };
+
+    viv_view_get_geometry(view, &geo_box);
+
+    int border_width = view->server->config->border_width;
+    geo_box.x -= border_width;
+    geo_box.y -= border_width;
+    geo_box.width += 2 * border_width;
+    geo_box.height += 2 * border_width;
+
     wl_list_for_each(output, &view->server->outputs, link) {
-        struct wlr_box geo_box;
-        viv_view_get_geometry(view, &geo_box);
-        /* wlr_output_damage_add_box(output->damage, &geo_box); */
         viv_output_damage_layout_coords_box(output, &geo_box);
     }
 }
@@ -180,11 +179,13 @@ void viv_view_make_active(struct viv_view *view) {
 void viv_view_set_size(struct viv_view *view, uint32_t width, uint32_t height) {
     ASSERT(view->implementation->set_size != NULL);
     view->implementation->set_size(view, width, height);
+    viv_view_damage(view);
 }
 
 void viv_view_set_pos(struct viv_view *view, uint32_t width, uint32_t height) {
     ASSERT(view->implementation->set_pos != NULL);
     view->implementation->set_pos(view, width, height);
+    viv_view_damage(view);
 }
 
 void viv_view_get_geometry(struct viv_view *view, struct wlr_box *geo_box) {

--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -9,6 +9,7 @@
 
 #include "viv_view.h"
 
+#include "viv_output.h"
 #include "viv_server.h"
 #include "viv_types.h"
 #include "viv_wl_list_utils.h"
@@ -146,23 +147,28 @@ bool viv_view_oversized(struct viv_view *view) {
     return view->implementation->oversized(view);
 }
 
+/* /// Return the view bounding box in coordinates relative to the given output */
+/* static struct wlr_box viv_view_output_coords(struct viv_view *view, struct viv_output *output) { */
+/*     double lx, ly; */
+/*     wlr_output_layout_output_coords(view->server->output_layout, output->wlr_output, &lx, &ly); */
+
+/*     struct wlr_box geo_box = { */
+/*         .x = view->target_x - lx, */
+/*         .y = view->target_y - ly, */
+/*         .width = view->target_width, */
+/*         .height = view->target_height, */
+/*     }; */
+
+/*     return geo_box; */
+/* } */
+
 void viv_view_damage(struct viv_view *view) {
     struct viv_output *output;
-
-    struct wlr_box geo_box = {
-        .x = view->target_x - 10,
-        .y = view->target_y - 10,
-        .width = view->target_width + 20,
-        .height = view->target_height + 20,
-    };
-    /* viv_view_get_geometry(view, &geo_box); */
-    // TODO: Subtract layout pos
-
-    /* geo_box.x = view->x; */
-    /* geo_box.y = view->y; */
-
     wl_list_for_each(output, &view->server->outputs, link) {
-        wlr_output_damage_add_box(output->damage, &geo_box);
+        struct wlr_box geo_box;
+        viv_view_get_geometry(view, &geo_box);
+        /* wlr_output_damage_add_box(output->damage, &geo_box); */
+        viv_output_damage_layout_coords_box(output, &geo_box);
     }
 }
 

--- a/src/viv_wlr_surface_tree.c
+++ b/src/viv_wlr_surface_tree.c
@@ -16,8 +16,6 @@ static void handle_subsurface_map (struct wl_listener *listener, void *data) {
     struct wlr_subsurface *wlr_subsurface = subsurface->wlr_subsurface;
 
     viv_surface_tree_subsurface_node_create(subsurface->server, subsurface->parent, subsurface, wlr_subsurface->surface);
-
-    wlr_log(WLR_INFO, "Mapped subsurface wlr_surface at %p", wlr_subsurface->surface);
 }
 
 static void handle_subsurface_unmap (struct wl_listener *listener, void *data) {
@@ -25,15 +23,12 @@ static void handle_subsurface_unmap (struct wl_listener *listener, void *data) {
     // do nothing?
     UNUSED(subsurface);
     UNUSED(data);
-    struct wlr_subsurface *wlr_subsurface = subsurface->wlr_subsurface;
-    wlr_log(WLR_INFO, "Unmapped subsurface wlr_surface at %p", wlr_subsurface->surface);
 }
 
 static void handle_subsurface_destroy (struct wl_listener *listener, void *data) {
     UNUSED(data);
     struct viv_wlr_subsurface *subsurface = wl_container_of(listener, subsurface, destroy);
-    wlr_log(WLR_INFO, "Subsurface destroy for wlr_subsurface at %p", subsurface->wlr_subsurface);
-    /* free(subsurface);  // ...is this safe? */
+    free(subsurface);  // ...is this safe?
 }
 
 static void handle_new_node_subsurface (struct wl_listener *listener, void *data) {
@@ -56,8 +51,6 @@ static void handle_new_node_subsurface (struct wl_listener *listener, void *data
 
     subsurface->destroy.notify = handle_subsurface_destroy;
     wl_signal_add(&wlr_subsurface->events.destroy, &subsurface->destroy);
-
-    wlr_log(WLR_INFO, "New subsurface for wlr_surface at %p", node->wlr_surface);
 }
 
 /// Walks up the surface tree until reaching the root, adding all the surface offsets along the way
@@ -86,18 +79,14 @@ static void handle_commit(struct wl_listener *listener, void *data) {
     int ly = 0;
     add_surface_global_offset(node, &lx, &ly);
     viv_damage_surface(node->server, surface, lx, ly);
-
-    wlr_log(WLR_INFO, "Committing surface at %p, x %d y %d", surface, lx, ly);
 }
 
 static void handle_node_destroy(struct wl_listener *listener, void *data) {
     UNUSED(data);
-    struct viv_surface_tree_node *node = wl_container_of(listener, node, commit);
-
-    wlr_log(WLR_INFO, "Node destroy for node with wlr_surface %p", node->wlr_surface);
+    struct viv_surface_tree_node *node = wl_container_of(listener, node, destroy);
 
     // TODO: Should we destroy all our children? Or are they guaranteed to be destroyed first?
-    /* free(node); */
+    free(node);
 }
 
 
@@ -121,8 +110,6 @@ static struct viv_surface_tree_node *viv_surface_tree_create(struct viv_server *
     wl_list_for_each(wlr_subsurface, &surface->subsurfaces, parent_link) {
         handle_new_node_subsurface(&node->new_subsurface, wlr_subsurface);
     }
-
-    wlr_log(WLR_INFO, "Created new viv_surface_tree_node for surface at %p", surface);
 
     return node;
 }

--- a/src/viv_wlr_surface_tree.c
+++ b/src/viv_wlr_surface_tree.c
@@ -1,0 +1,153 @@
+
+#include <wayland-util.h>
+#include <wlr/types/wlr_surface.h>
+
+#include "viv_damage.h"
+#include "viv_types.h"
+#include "viv_wlr_surface_tree.h"
+
+static struct viv_surface_tree_node *viv_surface_tree_create(struct viv_server *server,  struct wlr_surface *surface);
+static struct viv_surface_tree_node *viv_surface_tree_subsurface_node_create(struct viv_server *server, struct viv_surface_tree_node *parent,
+                                                                             struct viv_wlr_subsurface *subsurface, struct wlr_surface *surface);
+
+static void handle_subsurface_map (struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct viv_wlr_subsurface *subsurface = wl_container_of(listener, subsurface, map);
+    struct wlr_subsurface *wlr_subsurface = subsurface->wlr_subsurface;
+
+    viv_surface_tree_subsurface_node_create(subsurface->server, subsurface->parent, subsurface, wlr_subsurface->surface);
+
+    wlr_log(WLR_INFO, "Mapped subsurface wlr_surface at %p", wlr_subsurface->surface);
+}
+
+static void handle_subsurface_unmap (struct wl_listener *listener, void *data) {
+    struct viv_wlr_subsurface *subsurface = wl_container_of(listener, subsurface, unmap);
+    // do nothing?
+    UNUSED(subsurface);
+    UNUSED(data);
+    struct wlr_subsurface *wlr_subsurface = subsurface->wlr_subsurface;
+    wlr_log(WLR_INFO, "Unmapped subsurface wlr_surface at %p", wlr_subsurface->surface);
+}
+
+static void handle_subsurface_destroy (struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct viv_wlr_subsurface *subsurface = wl_container_of(listener, subsurface, destroy);
+    wlr_log(WLR_INFO, "Subsurface destroy for wlr_subsurface at %p", subsurface->wlr_subsurface);
+    /* free(subsurface);  // ...is this safe? */
+}
+
+static void handle_new_node_subsurface (struct wl_listener *listener, void *data) {
+    struct viv_surface_tree_node *node = wl_container_of(listener, node, new_subsurface);
+
+    struct wlr_subsurface *wlr_subsurface = data;
+
+    struct viv_wlr_subsurface *subsurface = calloc(1, sizeof(struct viv_wlr_subsurface));
+    CHECK_ALLOCATION(subsurface);
+
+    subsurface->server = node->server;
+    subsurface->wlr_subsurface = wlr_subsurface;
+    subsurface->parent = node;
+
+    subsurface->map.notify = handle_subsurface_map;
+    wl_signal_add(&wlr_subsurface->events.map, &subsurface->map);
+
+    subsurface->unmap.notify = handle_subsurface_unmap;
+    wl_signal_add(&wlr_subsurface->events.unmap, &subsurface->unmap);
+
+    subsurface->destroy.notify = handle_subsurface_destroy;
+    wl_signal_add(&wlr_subsurface->events.destroy, &subsurface->destroy);
+
+    wlr_log(WLR_INFO, "New subsurface for wlr_surface at %p", node->wlr_surface);
+}
+
+/// Walks up the surface tree until reaching the root, adding all the surface offsets along the way
+static void add_surface_global_offset(struct viv_surface_tree_node *node, int *lx, int *ly) {
+    *lx += node->wlr_surface->sx;
+    *ly += node->wlr_surface->sy;
+
+    if (node->apply_global_offset) {
+        // This is the root node
+        ASSERT(!node->subsurface);
+        node->apply_global_offset(node->global_offset_data, lx, ly);
+    } else {
+        ASSERT(node->subsurface);
+        lx += node->subsurface->wlr_subsurface->current.x;
+        ly += node->subsurface->wlr_subsurface->current.y;
+        add_surface_global_offset(node->parent, lx, ly);
+    }
+}
+
+static void handle_commit(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct viv_surface_tree_node *node = wl_container_of(listener, node, commit);
+    struct wlr_surface *surface = node->wlr_surface;
+
+    int lx = 0;
+    int ly = 0;
+    add_surface_global_offset(node, &lx, &ly);
+    viv_damage_surface(node->server, surface, lx, ly);
+
+    wlr_log(WLR_INFO, "Committing surface at %p, x %d y %d", surface, lx, ly);
+}
+
+static void handle_node_destroy(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct viv_surface_tree_node *node = wl_container_of(listener, node, commit);
+
+    wlr_log(WLR_INFO, "Node destroy for node with wlr_surface %p", node->wlr_surface);
+
+    // TODO: Should we destroy all our children? Or are they guaranteed to be destroyed first?
+    /* free(node); */
+}
+
+
+static struct viv_surface_tree_node *viv_surface_tree_create(struct viv_server *server,  struct wlr_surface *surface) {
+    struct viv_surface_tree_node *node = calloc(1, sizeof(struct viv_surface_tree_node));
+    CHECK_ALLOCATION(node);
+
+    node->server = server;
+    node->wlr_surface = surface;
+
+    node->new_subsurface.notify = handle_new_node_subsurface;
+    wl_signal_add(&surface->events.new_subsurface, &node->new_subsurface);
+
+    node->commit.notify = handle_commit;
+    wl_signal_add(&surface->events.commit, &node->commit);
+
+    node->destroy.notify = handle_node_destroy;
+    wl_signal_add(&surface->events.destroy, &node->destroy);
+
+    struct wlr_subsurface *wlr_subsurface;
+    wl_list_for_each(wlr_subsurface, &surface->subsurfaces, parent_link) {
+        handle_new_node_subsurface(&node->new_subsurface, wlr_subsurface);
+    }
+
+    wlr_log(WLR_INFO, "Created new viv_surface_tree_node for surface at %p", surface);
+
+    return node;
+}
+
+static struct viv_surface_tree_node *viv_surface_tree_subsurface_node_create(struct viv_server *server, struct viv_surface_tree_node *parent, struct viv_wlr_subsurface *subsurface, struct wlr_surface *surface) {
+    ASSERT(server);
+    ASSERT(parent);
+    ASSERT(subsurface);
+    ASSERT(surface);
+
+    struct viv_surface_tree_node *node = viv_surface_tree_create(server, surface);
+    node->parent = parent;
+    node->subsurface = subsurface;
+
+    return node;
+}
+
+struct viv_surface_tree_node *viv_surface_tree_root_create(struct viv_server *server, struct wlr_surface *surface, void (*apply_global_offset)(void *, int *, int *), void *global_offset_data) {
+    ASSERT(server);
+    ASSERT(surface);
+    ASSERT(apply_global_offset);
+
+    struct viv_surface_tree_node *node = viv_surface_tree_create(server, surface);
+    node->apply_global_offset = apply_global_offset;
+    node->global_offset_data = global_offset_data;
+
+    return node;
+}

--- a/src/viv_workspace.c
+++ b/src/viv_workspace.c
@@ -229,6 +229,9 @@ void viv_workspace_do_layout(struct viv_workspace *workspace) {
     workspace->was_laid_out = true;
 
     viv_workspace_damage_views(workspace);
+    if (workspace->output) {
+        viv_output_damage(workspace->output);
+    }
 }
 
 uint32_t viv_workspace_num_tiled_views(struct viv_workspace *workspace) {

--- a/src/viv_workspace.c
+++ b/src/viv_workspace.c
@@ -3,9 +3,19 @@
 
 #include "viv_cursor.h"
 #include "viv_layout.h"
+#include "viv_output.h"
 #include "viv_types.h"
 #include "viv_view.h"
 #include "viv_wl_list_utils.h"
+#include "viv_workspace.h"
+
+void viv_workspace_mark_for_relayout(struct viv_workspace *workspace) {
+    workspace->needs_layout = true;
+    viv_workspace_damage_views(workspace);  // TODO: is this 100% redundant with damaging the output?
+    if (workspace->output) {
+        viv_output_damage(workspace->output);
+    }
+}
 
 void viv_workspace_focus_next_window(struct viv_workspace *workspace) {
     struct viv_view *active_view = workspace->active_view;
@@ -58,7 +68,7 @@ void viv_workspace_shift_active_window_up(struct viv_workspace *workspace) {
 
     viv_wl_list_swap(&active_view->workspace_link, prev_link);
 
-    active_view->workspace->needs_layout = true;
+    viv_workspace_mark_for_relayout(active_view->workspace);
 }
 
 void viv_workspace_shift_active_window_down(struct viv_workspace *workspace) {
@@ -80,7 +90,7 @@ void viv_workspace_shift_active_window_down(struct viv_workspace *workspace) {
 
     viv_wl_list_swap(&active_view->workspace_link, next_link);
 
-    active_view->workspace->needs_layout = true;
+    viv_workspace_mark_for_relayout(active_view->workspace);
 }
 
 void viv_workspace_increment_divide(struct viv_workspace *workspace, float increment) {
@@ -91,7 +101,7 @@ void viv_workspace_increment_divide(struct viv_workspace *workspace, float incre
         workspace->active_layout->parameter = 0;
     }
 
-    workspace->needs_layout = true;
+    viv_workspace_mark_for_relayout(workspace);
 }
 
 void viv_workspace_increment_counter(struct viv_workspace *workspace, uint32_t increment) {
@@ -99,7 +109,7 @@ void viv_workspace_increment_counter(struct viv_workspace *workspace, uint32_t i
         workspace->active_layout->counter += increment;
     }
 
-    workspace->needs_layout = true;
+    viv_workspace_mark_for_relayout(workspace);
 }
 
 void viv_workspace_swap_out(struct viv_output *output, struct wl_list *workspaces) {
@@ -120,7 +130,7 @@ void viv_workspace_swap_out(struct viv_output *output, struct wl_list *workspace
     new_workspace->output = output;
     output->current_workspace = new_workspace;
 
-    output->needs_layout = true;
+    viv_output_mark_for_relayout(output);
 
     if (new_workspace->active_view != NULL) {
         viv_view_focus(new_workspace->active_view, viv_view_get_toplevel_surface(new_workspace->active_view));
@@ -137,7 +147,7 @@ void viv_workspace_next_layout(struct viv_workspace *workspace) {
     struct viv_layout *next_layout = wl_container_of(next_layout_link, next_layout, workspace_link);
     wlr_log(WLR_DEBUG, "Switching to layout with name %s", next_layout->name);
     workspace->active_layout = next_layout;
-    workspace->needs_layout = true;
+    viv_workspace_mark_for_relayout(workspace);
 }
 
 void viv_workspace_prev_layout(struct viv_workspace *workspace) {
@@ -148,7 +158,7 @@ void viv_workspace_prev_layout(struct viv_workspace *workspace) {
     struct viv_layout *prev_layout = wl_container_of(prev_layout_link, prev_layout, workspace_link);
     wlr_log(WLR_DEBUG, "Switching to layout with name %s", prev_layout->name);
     workspace->active_layout = prev_layout;
-    workspace->needs_layout = true;
+    viv_workspace_mark_for_relayout(workspace);
 }
 
 void viv_workspace_assign_to_output(struct viv_workspace *workspace, struct viv_output *output) {
@@ -182,10 +192,19 @@ void viv_workspace_swap_active_and_main(struct viv_workspace *workspace) {
     }
 
     viv_wl_list_swap(&active_view->workspace_link, &main_view->workspace_link);
-    workspace->needs_layout = true;
+    viv_workspace_mark_for_relayout(workspace);
+}
+
+void viv_workspace_damage_views(struct viv_workspace *workspace) {
+    struct viv_view *view;
+    wl_list_for_each(view, &workspace->views, workspace_link) {
+        viv_view_damage(view);
+    }
 }
 
 void viv_workspace_do_layout(struct viv_workspace *workspace) {
+    viv_workspace_damage_views(workspace);
+
     struct viv_output *output = workspace->output;
     ASSERT(output);
     struct viv_layout *layout = workspace->active_layout;
@@ -208,6 +227,8 @@ void viv_workspace_do_layout(struct viv_workspace *workspace) {
     viv_cursor_reset_focus(workspace->server, (int64_t)now.tv_sec * 1000 + now.tv_nsec / 1000000);
 
     workspace->was_laid_out = true;
+
+    viv_workspace_damage_views(workspace);
 }
 
 uint32_t viv_workspace_num_tiled_views(struct viv_workspace *workspace) {
@@ -235,5 +256,5 @@ void viv_workspace_add_view(struct viv_workspace *workspace, struct viv_view *vi
 
 	viv_view_focus(view, viv_view_get_toplevel_surface(view));
 
-    workspace->needs_layout = true;
+    viv_workspace_mark_for_relayout(workspace);
 }

--- a/src/viv_xdg_popup.c
+++ b/src/viv_xdg_popup.c
@@ -1,0 +1,61 @@
+
+#include "viv_damage.h"
+#include "viv_output.h"
+#include "viv_types.h"
+
+static void handle_popup_surface_commit(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct viv_xdg_popup *popup = wl_container_of(listener, popup, surface_commit);
+    struct wlr_surface *surface = popup->wlr_popup->base->surface;
+
+    pixman_region32_t damage;
+    pixman_region32_init(&damage);
+    wlr_surface_get_effective_damage(surface, &damage);
+
+    int px = *popup->lx + popup->wlr_popup->geometry.x;
+    int py = *popup->ly + popup->wlr_popup->geometry.y;
+    pixman_region32_translate(&damage, px, py);
+
+    viv_damage_surface(popup->server, surface, px, py);
+
+    pixman_region32_fini(&damage);
+}
+
+static void handle_popup_surface_unmap(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct viv_xdg_popup *popup = wl_container_of(listener, popup, surface_unmap);
+
+    int px = *popup->lx + popup->wlr_popup->geometry.x;
+    int py = *popup->ly + popup->wlr_popup->geometry.y;
+    struct wlr_box geo_box = {
+        .x = px,
+        .y = py,
+        .width = popup->wlr_popup->geometry.width,
+        .height = popup->wlr_popup->geometry.height,
+    };
+
+    struct viv_output *output;
+    wl_list_for_each(output, &popup->server->outputs, link) {
+        viv_output_damage_layout_coords_box(output, &geo_box);
+    }
+}
+
+static void handle_popup_surface_destroy(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+    struct viv_xdg_popup *popup = wl_container_of(listener, popup, destroy);
+    wlr_log(WLR_INFO, "Popup being destroyed");
+    free(popup);
+}
+
+void viv_xdg_popup_init(struct viv_xdg_popup *popup, struct wlr_xdg_popup *wlr_popup) {
+    popup->wlr_popup = wlr_popup;
+
+    popup->surface_commit.notify = handle_popup_surface_commit;
+    wl_signal_add(&wlr_popup->base->surface->events.commit, &popup->surface_commit);
+
+    popup->surface_unmap.notify = handle_popup_surface_unmap;
+    wl_signal_add(&wlr_popup->base->events.unmap, &popup->surface_unmap);
+
+    popup->destroy.notify = handle_popup_surface_destroy;
+    wl_signal_add(&wlr_popup->base->surface->events.destroy, &popup->destroy);
+}

--- a/src/viv_xdg_popup.c
+++ b/src/viv_xdg_popup.c
@@ -37,8 +37,10 @@ static void handle_popup_surface_unmap(struct wl_listener *listener, void *data)
     UNUSED(data);
     struct viv_xdg_popup *popup = wl_container_of(listener, popup, surface_unmap);
 
-    int px = *popup->lx + popup->wlr_popup->geometry.x;
-    int py = *popup->ly + popup->wlr_popup->geometry.y;
+    int px = 0;
+    int py = 0;
+    add_popup_global_coords(popup, &px, &py);
+
     struct wlr_box geo_box = {
         .x = px,
         .y = py,
@@ -56,7 +58,7 @@ static void handle_popup_surface_destroy(struct wl_listener *listener, void *dat
     UNUSED(data);
     struct viv_xdg_popup *popup = wl_container_of(listener, popup, destroy);
     wlr_log(WLR_INFO, "Popup being destroyed");
-    /* free(popup); */
+    free(popup);
 }
 
 static void handle_new_popup(struct wl_listener *listener, void *data) {

--- a/src/viv_xdg_popup.c
+++ b/src/viv_xdg_popup.c
@@ -3,22 +3,34 @@
 #include "viv_output.h"
 #include "viv_types.h"
 
-static void handle_popup_surface_commit(struct wl_listener *listener, void *data) {
-    UNUSED(data);
-    struct viv_xdg_popup *popup = wl_container_of(listener, popup, surface_commit);
-    struct wlr_surface *surface = popup->wlr_popup->base->surface;
+#include "viv_xdg_popup.h"
+#include "viv_wlr_surface_tree.h"
 
-    pixman_region32_t damage;
-    pixman_region32_init(&damage);
-    wlr_surface_get_effective_damage(surface, &damage);
+/// Add to x and y the global (i.e. output-layout) coords of the input popup, calculated
+/// by walking up the popup tree and adding the geometry of each parent.
+static void add_popup_global_coords(void *popup_pointer, int *x, int *y) {
+    struct viv_xdg_popup *popup = popup_pointer;
 
-    int px = *popup->lx + popup->wlr_popup->geometry.x;
-    int py = *popup->ly + popup->wlr_popup->geometry.y;
-    pixman_region32_translate(&damage, px, py);
+    int px = 0;
+    int py = 0;
 
-    viv_damage_surface(popup->server, surface, px, py);
+    struct viv_xdg_popup *cur_popup = popup;
+    while (true) {
+        px += cur_popup->wlr_popup->geometry.x;
+        py += cur_popup->wlr_popup->geometry.y;
 
-    pixman_region32_fini(&damage);
+        if (cur_popup->parent_popup != NULL) {
+            cur_popup = cur_popup->parent_popup;
+        } else {
+            break;
+        }
+    }
+
+    px += *popup->lx;
+    py += *popup->ly;
+
+    *x += px;
+    *y += py;
 }
 
 static void handle_popup_surface_unmap(struct wl_listener *listener, void *data) {
@@ -44,18 +56,36 @@ static void handle_popup_surface_destroy(struct wl_listener *listener, void *dat
     UNUSED(data);
     struct viv_xdg_popup *popup = wl_container_of(listener, popup, destroy);
     wlr_log(WLR_INFO, "Popup being destroyed");
-    free(popup);
+    /* free(popup); */
+}
+
+static void handle_new_popup(struct wl_listener *listener, void *data) {
+    struct viv_xdg_popup *popup = wl_container_of(listener, popup, new_popup);
+	struct wlr_xdg_popup *wlr_popup = data;
+
+    struct viv_xdg_popup *new_popup = calloc(1, sizeof(struct viv_xdg_popup));
+    new_popup->server = popup->server;
+    new_popup->lx = popup->lx;
+    new_popup->ly = popup->ly;
+    new_popup->parent_popup = popup;
+    viv_xdg_popup_init(new_popup, wlr_popup);
 }
 
 void viv_xdg_popup_init(struct viv_xdg_popup *popup, struct wlr_xdg_popup *wlr_popup) {
     popup->wlr_popup = wlr_popup;
 
-    popup->surface_commit.notify = handle_popup_surface_commit;
-    wl_signal_add(&wlr_popup->base->surface->events.commit, &popup->surface_commit);
+    wlr_log(WLR_INFO, "New popup %p with parent %p", popup, popup->parent_popup);
+
+    viv_surface_tree_root_create(popup->server, wlr_popup->base->surface, &add_popup_global_coords, popup);
 
     popup->surface_unmap.notify = handle_popup_surface_unmap;
     wl_signal_add(&wlr_popup->base->events.unmap, &popup->surface_unmap);
 
     popup->destroy.notify = handle_popup_surface_destroy;
     wl_signal_add(&wlr_popup->base->surface->events.destroy, &popup->destroy);
+
+    popup->new_popup.notify = handle_new_popup;
+    wl_signal_add(&wlr_popup->base->events.new_popup, &popup->new_popup);
+
+    wlr_log(WLR_INFO, "New wlr_popup surface at %p", wlr_popup->base->surface);
 }

--- a/src/viv_xdg_shell.c
+++ b/src/viv_xdg_shell.c
@@ -4,11 +4,13 @@
 #include <wlr/types/wlr_output_damage.h>
 
 #include "viv_config_support.h"
+#include "viv_damage.h"
 #include "viv_xdg_shell.h"
 #include "viv_server.h"
 #include "viv_types.h"
 #include "viv_view.h"
 #include "viv_workspace.h"
+#include "viv_xdg_popup.h"
 
 /// Return true if the view looks like it should be floating.
 // TODO: Make this more robust
@@ -21,19 +23,9 @@ static void handle_xdg_surface_commit(struct wl_listener *listener, void *data) 
     struct viv_view *view = wl_container_of(listener, view, surface_commit);
     struct wlr_surface *surface = view->xdg_surface->surface;
 
-    pixman_region32_t damage;
-    pixman_region32_init(&damage);
-    wlr_surface_get_effective_damage(surface, &damage);
-
-    pixman_region32_translate(&damage, view->x, view->y);
-
-    struct viv_output *viv_output = wl_container_of(view->server->outputs.next, viv_output, link);
-    struct wlr_output_damage *output_damage = viv_output->damage;
-    wlr_output_damage_add(output_damage, &damage);
+    viv_damage_surface(view->server, surface, view->x, view->y);
 
     wlr_log(WLR_DEBUG, "view %s commit", view->xdg_surface->toplevel->app_id);
-
-    pixman_region32_fini(&damage);
 }
 
 static void xdg_surface_map(struct wl_listener *listener, void *data) {
@@ -258,68 +250,15 @@ static struct viv_view_implementation xdg_view_implementation = {
     .oversized = &implementation_oversized,
 };
 
-static void handle_popup_surface_commit(struct wl_listener *listener, void *data) {
-    UNUSED(data);
-    struct viv_xdg_popup *popup = wl_container_of(listener, popup, surface_commit);
-    struct viv_view *view = popup->view;
-    struct wlr_surface *surface = popup->wlr_popup->base->surface;
-
-    pixman_region32_t damage;
-    pixman_region32_init(&damage);
-    wlr_surface_get_effective_damage(surface, &damage);
-
-    pixman_region32_translate(&damage, view->x + popup->wlr_popup->geometry.x, view->y + popup->wlr_popup->geometry.y);
-
-    struct viv_output *viv_output = wl_container_of(view->server->outputs.next, viv_output, link);
-    struct wlr_output_damage *output_damage = viv_output->damage;
-    wlr_output_damage_add(output_damage, &damage);
-
-    wlr_log(WLR_DEBUG, "popup for view %s commit", view->xdg_surface->toplevel->app_id);
-
-    pixman_region32_fini(&damage);
-}
-
-static void handle_popup_surface_unmap(struct wl_listener *listener, void *data) {
-    UNUSED(data);
-    struct viv_xdg_popup *popup = wl_container_of(listener, popup, surface_unmap);
-    struct viv_view *view = popup->view;
-
-    struct wlr_box geo_box = {
-        .x = view->x + popup->wlr_popup->geometry.x,
-        .y = view->y + popup->wlr_popup->geometry.y,
-        .width = popup->wlr_popup->geometry.width,
-        .height = popup->wlr_popup->geometry.height,
-    };
-
-    struct viv_output *output;
-    wl_list_for_each(output, &view->server->outputs, link) {
-        wlr_output_damage_add_box(output->damage, &geo_box);
-    }
-}
-
-static void handle_popup_surface_destroy(struct wl_listener *listener, void *data) {
-    UNUSED(data);
-    struct viv_xdg_popup *popup = wl_container_of(listener, popup, destroy);
-    wlr_log(WLR_INFO, "Popup being destroyed");
-    free(popup);
-}
-
 static void handle_xdg_surface_new_popup(struct wl_listener *listener, void *data) {
     struct viv_view *view = wl_container_of(listener, view, new_xdg_popup);
 	struct wlr_xdg_popup *wlr_popup = data;
 
     struct viv_xdg_popup *popup = calloc(1, sizeof(struct viv_xdg_popup));
-    popup->view = view;
-    popup->wlr_popup = wlr_popup;
-
-    popup->surface_commit.notify = handle_popup_surface_commit;
-    wl_signal_add(&wlr_popup->base->surface->events.commit, &popup->surface_commit);
-
-    popup->surface_unmap.notify = handle_popup_surface_unmap;
-    wl_signal_add(&wlr_popup->base->events.unmap, &popup->surface_unmap);
-
-    popup->destroy.notify = handle_popup_surface_destroy;
-    wl_signal_add(&wlr_popup->base->surface->events.destroy, &popup->destroy);
+    viv_xdg_popup_init(popup, wlr_popup);
+    popup->server = view->server;
+    popup->lx = &view->x;
+    popup->ly = &view->y;
 }
 
 void viv_xdg_view_init(struct viv_view *view, struct wlr_xdg_surface *xdg_surface) {

--- a/src/viv_xdg_shell.c
+++ b/src/viv_xdg_shell.c
@@ -23,9 +23,6 @@ static void add_xdg_view_global_coords(void *view_pointer, int *x, int *y) {
     struct viv_view *view = view_pointer;
     *x += view->x;
     *y += view->y;
-
-    /* *x += view->xdg_surface->geometry.x; */
-    /* *y += view->xdg_surface->geometry.y; */
 }
 
 static void xdg_surface_map(struct wl_listener *listener, void *data) {
@@ -63,8 +60,6 @@ static void xdg_surface_map(struct wl_listener *listener, void *data) {
     viv_workspace_add_view(view->workspace, view);
 
     viv_surface_tree_root_create(view->server, view->xdg_surface->surface, &add_xdg_view_global_coords, view);
-
-    wlr_log(WLR_INFO, "Mapped xdg-surface wlr_surface at %p", view->xdg_surface->surface);
 }
 
 static void xdg_surface_unmap(struct wl_listener *listener, void *data) {

--- a/src/viv_xwayland_shell.c
+++ b/src/viv_xwayland_shell.c
@@ -2,6 +2,7 @@
 #include <wlr/types/wlr_output_damage.h>
 #include <xcb/xcb.h>
 
+#include "viv_damage.h"
 #include "viv_types.h"
 #include "viv_view.h"
 #include "viv_workspace.h"
@@ -114,17 +115,7 @@ static void handle_xwayland_surface_commit(struct wl_listener *listener, void *d
     struct viv_view *view = wl_container_of(listener, view, surface_commit);
     struct wlr_surface *surface = view->xwayland_surface->surface;
 
-    pixman_region32_t damage;
-    pixman_region32_init(&damage);
-    wlr_surface_get_effective_damage(surface, &damage);
-
-    pixman_region32_translate(&damage, view->x, view->y);
-
-    struct viv_output *viv_output = wl_container_of(view->server->outputs.next, viv_output, link);
-    struct wlr_output_damage *output_damage = viv_output->damage;
-    wlr_output_damage_add(output_damage, &damage);
-
-    pixman_region32_fini(&damage);
+    viv_damage_surface(view->server, surface, view->x, view->y);
 }
 
 static void event_xwayland_surface_map(struct wl_listener *listener, void *data) {

--- a/src/vivarium.c
+++ b/src/vivarium.c
@@ -43,13 +43,14 @@ int main(int argc, char *argv[]) {
     UNUSED(argc);
     UNUSED(argv);
 
-    viv_cli_parse_args(argc, argv);
+    struct viv_args parsed_args = viv_cli_parse_args(argc, argv);
 
 	wlr_log_init(WLR_DEBUG, NULL);
 
     // Initialise our vivarium server. This sets up all the event bindings so that inputs,
     // outputs and window events can be handles.
 	struct viv_server server = { .config = NULL };
+    server.user_provided_config_filen = parsed_args.config_filen;
     viv_server_init(&server);
 
 	// Add a Unix socket to the Wayland display.

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -77,6 +77,10 @@ void test_config_toml_static_options_match_defaults(void) {
 
     TEST_ASSERT_CONFIG_EQUAL(debug_mark_views_by_shell);
     TEST_ASSERT_CONFIG_EQUAL(debug_mark_active_output);
+    TEST_ASSERT_CONFIG_EQUAL(debug_draw_only_damaged_regions);
+    TEST_ASSERT_CONFIG_EQUAL(debug_mark_frame_draws);
+
+    TEST_ASSERT_CONFIG_EQUAL(damage_tracking_mode);
 }
 
 void test_config_toml_workspaces_match_defaults(void) {

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -77,7 +77,7 @@ void test_config_toml_static_options_match_defaults(void) {
 
     TEST_ASSERT_CONFIG_EQUAL(debug_mark_views_by_shell);
     TEST_ASSERT_CONFIG_EQUAL(debug_mark_active_output);
-    TEST_ASSERT_CONFIG_EQUAL(debug_draw_only_damaged_regions);
+    TEST_ASSERT_CONFIG_EQUAL(debug_mark_undamaged_regions);
     TEST_ASSERT_CONFIG_EQUAL(debug_mark_frame_draws);
 
     TEST_ASSERT_CONFIG_EQUAL(damage_tracking_mode);


### PR DESCRIPTION
This is WIP for now.

In this PR I intend to get to the point where unchanged frames are not drawn but probably won't try to only draw changed regions just yet. This is because true damage tracking needs more careful debugging to avoid missing anything, especially when views are on multiple outputs with different scales, transforms etc., which I'm not yet testing.

Fixes #37 

TODO:
- [x] Initial code for frame-based drawing based on damage tracking
- [x] Test out debug options for indicating damage
- [x] Skip rendering for windows where damage doesn't overlap window region
- [x] Xdg surface, xwayland surface, layer surface damage tracking
- [x] Make layer surface rendering correctly scissor to damaged areas
- [x] Damage tracking for layer surface popups
- [x] Correct damage tracking offsets for subsurfaces and nested popups
- [x] Refactor damage tracking code to not be terrible
- [x] Add cli arguments to manipulate extent of damage tracking
- [x] Add cli debug arguments to manipulate damage tracking helper drawings
- [x] Set default damage tracking to whole-frame
- [x] Make sure all surface handlers are correctly freed on surface delete
- [x] Make some attempt to have damage tracking correctly follow output transformations (but not a priority for getting working whole-frame version merged)
- [x] Fix window border damage tracking (doesn't currently work right on creation, border isn't properly damaged so flickers)
- [x] Briefly dogfood to find remaining issues