### PR TITLE
Don't build wlroots examples if building from subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -35,7 +35,8 @@ endif
 cc = meson.get_compiler('c')
 
 # For wlroots, use the system version if the correct version is available
-wlroots_dep = dependency('wlroots', version : '0.12.0', fallback : ['wlroots', 'wlroots'])
+wlroots_dep = dependency('wlroots', version : '0.12.0', fallback : ['wlroots', 'wlroots'],
+                         default_options : ['examples=false'])
 
 tomlc99_dep = dependency('toml', fallback : ['tomlc99', 'tomlc99_static_dep'])
 


### PR DESCRIPTION
Fixes #44 

The wlroots 0.12.0 examples are outdated for the latest versions of dependencies, which is already a problem on Arch linux. There's actually no need to build the examples, so just skipping them by default should be fine.