### PR TITLE
Fix bug with wlr_subsurface offset not being applied

### DIFF
--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -119,6 +119,7 @@ struct viv_output {
 	struct wl_list link;
 	struct viv_server *server;
 	struct wlr_output *wlr_output;
+
 	struct wl_listener frame;
 
     struct wlr_output_damage *damage;
@@ -254,8 +255,6 @@ struct viv_workspace {
 
     struct viv_server *server;
     struct viv_output *output;
-
-    /* void (*do_layout)(struct viv_workspace *workspace); */
 
     struct wl_list views;  /// Ordered list of views associated with this workspace
     struct viv_view *active_view;  /// The view that currently has focus within the workspace

--- a/src/viv_wlr_surface_tree.c
+++ b/src/viv_wlr_surface_tree.c
@@ -64,8 +64,10 @@ static void add_surface_global_offset(struct viv_surface_tree_node *node, int *l
         node->apply_global_offset(node->global_offset_data, lx, ly);
     } else {
         ASSERT(node->subsurface);
-        lx += node->subsurface->wlr_subsurface->current.x;
-        ly += node->subsurface->wlr_subsurface->current.y;
+
+        *lx += node->subsurface->wlr_subsurface->current.x;
+        *ly += node->subsurface->wlr_subsurface->current.y;
+
         add_surface_global_offset(node->parent, lx, ly);
     }
 }


### PR DESCRIPTION
Fixes #58 - this pointer dereference typo totally messes up the offset used for damage tracking.