### PR TITLE
Make child popups inherit output from their parent

### DIFF
--- a/src/viv_xdg_popup.c
+++ b/src/viv_xdg_popup.c
@@ -70,6 +70,7 @@ static void handle_new_popup(struct wl_listener *listener, void *data) {
     new_popup->lx = popup->lx;
     new_popup->ly = popup->ly;
     new_popup->parent_popup = popup;
+    new_popup->output = popup->output;
     viv_xdg_popup_init(new_popup, wlr_popup);
 }
 


### PR DESCRIPTION
Child popups were broken by #66 - I missed a place where the output needed to be set!

Another strike in favour of properly passing necessary arguments to init, instead of doing it ad-hoc.