### PR TITLE
Properly clear up outputs when destroyed

### DIFF
--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -200,7 +200,6 @@ struct viv_xdg_popup {
     struct wlr_xdg_popup *wlr_popup;
     struct viv_xdg_popup *parent_popup;
     struct viv_server *server;
-    struct viv_output *output;
 
     struct viv_surface_tree_node *surface_tree;
 

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -121,6 +121,11 @@ struct viv_output {
 	struct wlr_output *wlr_output;
 
 	struct wl_listener frame;
+	struct wl_listener damage_event;
+	struct wl_listener present;
+	struct wl_listener enable;
+	struct wl_listener mode;
+	struct wl_listener destroy;
 
     struct wlr_output_damage *damage;
 

--- a/src/viv_cursor.c
+++ b/src/viv_cursor.c
@@ -124,7 +124,13 @@ static void process_cursor_pass_through_to_surface(struct viv_server *server, ui
         }
     } else if (view) {
         // View under the cursor and not already active => focus it if appropriate
-        struct viv_view *active_view = server->active_output->current_workspace->active_view;
+        struct viv_view *active_view = NULL;
+
+        struct viv_output *active_output = server->active_output;
+        if (active_output) {
+            active_view = active_output->current_workspace->active_view;
+        }
+
         if ((view != active_view) && server->config->focus_follows_mouse) {
             viv_view_focus(view, surface);
         }

--- a/src/viv_ipc.c
+++ b/src/viv_ipc.c
@@ -39,6 +39,11 @@ void viv_routine_log_state(struct viv_server *server) {
         return;
     }
 
+    if (!server->active_output) {
+        // Don't try to log anything, we aren't expecting anything to really change
+        return;
+    }
+
     if ((server->log_state.last_active_output == server->active_output) &&
         (server->log_state.last_active_workspace == server->active_output->current_workspace)) {
         // Nothing loggable has changed

--- a/src/viv_layer_view.c
+++ b/src/viv_layer_view.c
@@ -50,7 +50,11 @@ static void layer_surface_unmap(struct wl_listener *listener, void *data) {
         seat->keyboard_state.focused_surface = NULL;
     }
 
-    struct viv_view *active_view = layer_view->server->active_output->current_workspace->active_view;
+    struct viv_view *active_view = NULL;
+    if (layer_view->server->active_output) {
+        active_view = layer_view->server->active_output->current_workspace->active_view;
+    }
+
     if (active_view != NULL) {
         viv_view_focus(active_view, NULL);
     }

--- a/src/viv_layer_view.c
+++ b/src/viv_layer_view.c
@@ -43,14 +43,14 @@ static void layer_surface_unmap(struct wl_listener *listener, void *data) {
 
     viv_output_mark_for_relayout(layer_view->output);
 
-	struct wlr_seat *seat = layer_view->output->server->seat;
+	struct wlr_seat *seat = layer_view->server->seat;
 	struct wlr_surface *prev_surface = seat->keyboard_state.focused_surface;
     struct wlr_surface *our_surface = layer_view->layer_surface->surface;
     if (prev_surface == our_surface) {
         seat->keyboard_state.focused_surface = NULL;
     }
 
-    struct viv_view *active_view = layer_view->output->server->active_output->current_workspace->active_view;
+    struct viv_view *active_view = layer_view->server->active_output->current_workspace->active_view;
     if (active_view != NULL) {
         viv_view_focus(active_view, NULL);
     }
@@ -78,6 +78,11 @@ static void layer_surface_destroy(struct wl_listener *listener, void *data) {
         viv_surface_tree_destroy(layer_view->surface_tree);
         layer_view->surface_tree = NULL;
     }
+
+    wl_list_remove(&layer_view->map.link);
+    wl_list_remove(&layer_view->unmap.link);
+    wl_list_remove(&layer_view->destroy.link);
+    wl_list_remove(&layer_view->new_popup.link);
 
 	free(layer_view);
 }

--- a/src/viv_layer_view.c
+++ b/src/viv_layer_view.c
@@ -97,7 +97,6 @@ static void layer_surface_new_popup(struct wl_listener *listener, void *data) {
     popup->lx = &layer_view->x;
     popup->ly = &layer_view->y;
     popup->server = layer_view->server;
-    popup->output = layer_view->output;
     viv_xdg_popup_init(popup, wlr_popup);
 
 }

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -110,33 +110,31 @@ static void output_frame(struct wl_listener *listener, void *data) {
 
 static void output_damage_event(struct wl_listener *listener, void *data) {
     UNUSED(data);
-	struct viv_output *output = wl_container_of(listener, output, damage_event);
+    struct viv_output *output = wl_container_of(listener, output, damage_event);
     wlr_log(WLR_INFO, "Output \"%s\" event: damage", output->wlr_output->name);
 }
 
 static void output_present(struct wl_listener *listener, void *data) {
     UNUSED(listener);
     UNUSED(data);
-	/* struct viv_output *output = wl_container_of(listener, output, frame); */
-    /* wlr_log(WLR_INFO, "Output \"%s\" event: present", output->wlr_output->name); */
 }
 
 static void output_enable(struct wl_listener *listener, void *data) {
     UNUSED(data);
-	struct viv_output *output = wl_container_of(listener, output, enable);
+    struct viv_output *output = wl_container_of(listener, output, enable);
 
     wlr_log(WLR_INFO, "Output \"%s\" event: enable became %d", output->wlr_output->name, output->wlr_output->enabled);
 }
 
 static void output_mode(struct wl_listener *listener, void *data) {
     UNUSED(data);
-	struct viv_output *output = wl_container_of(listener, output, mode);
+    struct viv_output *output = wl_container_of(listener, output, mode);
     wlr_log(WLR_INFO, "Output \"%s\" event: mode", output->wlr_output->name);
 }
 
 static void output_destroy(struct wl_listener *listener, void *data) {
     UNUSED(data);
-	struct viv_output *output = wl_container_of(listener, output, destroy);
+    struct viv_output *output = wl_container_of(listener, output, destroy);
     wlr_log(WLR_INFO, "Output \"%s\" event: destroy", output->wlr_output->name);
 
     stop_using_output(output);

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -48,6 +48,36 @@ static void output_frame(struct wl_listener *listener, void *data) {
     viv_routine_log_state(output->server);
 }
 
+static void output_damage_event(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+	struct viv_output *output = wl_container_of(listener, output, frame);
+    wlr_log(WLR_INFO, "Output \"%s\" event: damage", output->wlr_output->name);
+}
+
+static void output_present(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+	struct viv_output *output = wl_container_of(listener, output, frame);
+    wlr_log(WLR_INFO, "Output \"%s\" event: present", output->wlr_output->name);
+}
+
+static void output_enable(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+	struct viv_output *output = wl_container_of(listener, output, frame);
+    wlr_log(WLR_INFO, "Output \"%s\" event: enable", output->wlr_output->name);
+}
+
+static void output_mode(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+	struct viv_output *output = wl_container_of(listener, output, frame);
+    wlr_log(WLR_INFO, "Output \"%s\" event: mode", output->wlr_output->name);
+}
+
+static void output_destroy(struct wl_listener *listener, void *data) {
+    UNUSED(data);
+	struct viv_output *output = wl_container_of(listener, output, frame);
+    wlr_log(WLR_INFO, "Output \"%s\" event: destroy", output->wlr_output->name);
+}
+
 struct viv_output *viv_output_at(struct viv_server *server, double lx, double ly) {
 
     struct wlr_output *wlr_output_at_point = wlr_output_layout_output_at(server->output_layout, lx, ly);
@@ -155,10 +185,24 @@ void viv_output_init(struct viv_output *output, struct viv_server *server, struc
 
     output->damage = wlr_output_damage_create(output->wlr_output);
 
-	/* Sets up a listener for the frame notify event. */
 	output->frame.notify = output_frame;
 	wl_signal_add(&output->damage->events.frame, &output->frame);
 	wl_list_insert(&server->outputs, &output->link);
+
+	output->damage_event.notify = output_damage_event;
+	wl_signal_add(&output->wlr_output->events.damage, &output->damage_event);
+	output->present.notify = output_present;
+	wl_signal_add(&output->wlr_output->events.present, &output->present);
+	output->enable.notify = output_enable;
+	wl_signal_add(&output->wlr_output->events.enable, &output->enable);
+	output->mode.notify = output_mode;
+	wl_signal_add(&output->wlr_output->events.mode, &output->mode);
+	output->destroy.notify = output_destroy;
+	wl_signal_add(&output->wlr_output->events.destroy, &output->destroy);
+
+
+	wl_list_insert(&server->outputs, &output->link);
+
     wlr_log(WLR_INFO, "New output width width %d, height %d", wlr_output->width, wlr_output->height);
 
     struct viv_workspace *current_workspace;

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -115,6 +115,12 @@ static void output_destroy(struct wl_listener *listener, void *data) {
 	struct viv_output *output = wl_container_of(listener, output, destroy);
     wlr_log(WLR_INFO, "Output \"%s\" event: destroy", output->wlr_output->name);
 
+    struct viv_layer_view *layer_view;
+    wl_list_for_each(layer_view, &output->layer_views, output_link){
+        layer_view->output = NULL;
+        wlr_layer_surface_v1_close(layer_view->layer_surface);
+    }
+
     stop_using_output(output);
 
     wl_list_remove(&output->frame.link);
@@ -314,5 +320,9 @@ void viv_output_layout_coords_box_to_output_coords(struct viv_output *output, st
 }
 
 void viv_output_mark_for_relayout(struct viv_output *output) {
-    viv_output_damage(output);
+    if (output) {
+        viv_output_damage(output);
+    } else {
+        wlr_log(WLR_ERROR, "Tried to mark NULL output for relayout");
+    }
 }

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -37,6 +37,21 @@ static void stop_using_output(struct viv_output *output) {
     struct viv_server *server = output->server;
     wl_list_remove(&output->link);
 
+    if (server->active_output == output) {
+        server->active_output = NULL;
+
+        // Set a new active output if any are available
+        struct viv_output *new_active_output;
+        wl_list_for_each(new_active_output, &server->outputs, link) {
+            viv_output_make_active(new_active_output);
+            break;
+        }
+    }
+
+    if (server->log_state.last_active_output == output) {
+        server->log_state.last_active_output = NULL;
+    }
+
     struct viv_workspace *current_workspace;
     wl_list_for_each(current_workspace, &server->workspaces, server_link) {
         if (current_workspace->output == output) {

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -732,7 +732,9 @@ void viv_check_data_consistency(struct viv_server *server) {
     struct viv_output *output;
     wl_list_for_each(output, &server->outputs, link) {
         DEBUG_ASSERT_EQUAL(output->server, server);
-        DEBUG_ASSERT_EQUAL(output->current_workspace->output, output);
+        if (output->current_workspace) {
+            DEBUG_ASSERT_EQUAL(output->current_workspace->output, output);
+        }
     }
 
     struct viv_workspace *workspace;

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -363,7 +363,7 @@ static void server_new_output(struct wl_listener *listener, void *data) {
 
     // If there isn't already an active output, we may as well use this one
     if (!server->active_output) {
-        server->active_output = output;
+        viv_output_make_active(output);
     }
 }
 

--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -203,7 +203,14 @@ void viv_view_init(struct viv_view *view, struct viv_server *server) {
 
     // Make sure the view gets added to a workspace
     struct viv_output *output = server->active_output;
-    view->workspace = output->current_workspace;
+
+    if (output) {
+        view->workspace = output->current_workspace;
+    } else {
+        // No output active (=> no outputs available), so just stick in the first workspace
+        struct viv_workspace *workspace = wl_container_of(&server->workspaces.next, workspace, server_link);
+        view->workspace = workspace;
+    }
 
     viv_view_ensure_tiled(view);
 

--- a/src/viv_xdg_popup.c
+++ b/src/viv_xdg_popup.c
@@ -87,14 +87,13 @@ static void handle_new_popup(struct wl_listener *listener, void *data) {
     new_popup->lx = popup->lx;
     new_popup->ly = popup->ly;
     new_popup->parent_popup = popup;
-    new_popup->output = popup->output;
     viv_xdg_popup_init(new_popup, wlr_popup);
 }
 
 /// Set the region in which the popup can be displayed, so that its position is shifted to
 /// stay within its output and not be rendered offscreen
 static void popup_unconstrain(struct viv_xdg_popup *popup) {
-    struct viv_output *output = popup->output;
+    struct viv_output *output = popup->server->active_output;
     struct wlr_xdg_popup *wlr_popup = popup->wlr_popup;
 
     double lx = 0, ly = 0;

--- a/src/viv_xdg_popup.c
+++ b/src/viv_xdg_popup.c
@@ -94,6 +94,10 @@ static void handle_new_popup(struct wl_listener *listener, void *data) {
 /// stay within its output and not be rendered offscreen
 static void popup_unconstrain(struct viv_xdg_popup *popup) {
     struct viv_output *output = popup->server->active_output;
+    if (!output) {
+        wlr_log(WLR_ERROR, "Cannot unconstraint popup, no active output");
+    }
+
     struct wlr_xdg_popup *wlr_popup = popup->wlr_popup;
 
     double lx = 0, ly = 0;

--- a/src/viv_xdg_shell.c
+++ b/src/viv_xdg_shell.c
@@ -266,7 +266,6 @@ static void handle_xdg_surface_new_popup(struct wl_listener *listener, void *dat
     popup->server = view->server;
     popup->lx = &view->x;
     popup->ly = &view->y;
-    popup->output = view->workspace->output;
     viv_xdg_popup_init(popup, wlr_popup);
 }
 


### PR DESCRIPTION
Currently vivarium mostly crashes on output destroy as it doesn't remotely clean up properly. Let's fix that.

Fixes #30 