### PR TITLE
Clear server grab state if grabbed view is unmapped

### DIFF
--- a/include/viv_server.h
+++ b/include/viv_server.h
@@ -36,4 +36,8 @@ void viv_surface_focus(struct viv_server *server, struct wlr_surface *surface);
 
 /// Reload the TOML config file
 void viv_server_reload_config(struct viv_server *server);
+
+/// Clear the server grab state, i.e. set cursor mode to passthrough and invalidate the
+/// grabbed view pointer
+void viv_server_clear_grab_state(struct viv_server *server);
 #endif

--- a/src/viv_cursor.c
+++ b/src/viv_cursor.c
@@ -9,7 +9,6 @@
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/util/edges.h>
 
-
 static void process_cursor_move_view(struct viv_server *server, uint32_t time) {
     UNUSED(time);
 

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -59,6 +59,11 @@
 #include "viv_config.h"
 #include "viv_config_support.h"
 
+void viv_server_clear_grab_state(struct viv_server *server) {
+        server->grab_state.view = NULL;
+        server->cursor_mode = VIV_CURSOR_PASSTHROUGH;
+}
+
 struct viv_workspace *viv_server_retrieve_workspace_by_name(struct viv_server *server, char *name) {
     struct viv_workspace *workspace;
     wl_list_for_each(workspace, &server->workspaces, server_link) {

--- a/src/viv_xdg_shell.c
+++ b/src/viv_xdg_shell.c
@@ -128,6 +128,10 @@ static void xdg_surface_destroy(struct wl_listener *listener, void *data) {
     }
 
     viv_view_destroy(view);
+
+    if (view->server->grab_state.view == view) {
+        viv_server_clear_grab_state(view->server);
+    }
 }
 
 static void xdg_toplevel_request_move(struct wl_listener *listener, void *data) {

--- a/src/viv_xwayland_shell.c
+++ b/src/viv_xwayland_shell.c
@@ -3,6 +3,7 @@
 #include <xcb/xcb.h>
 
 #include "viv_damage.h"
+#include "viv_server.h"
 #include "viv_types.h"
 #include "viv_view.h"
 #include "viv_wlr_surface_tree.h"
@@ -226,6 +227,10 @@ static void event_xwayland_surface_unmap(struct wl_listener *listener, void *dat
 
     viv_surface_tree_destroy(view->surface_tree);
     view->surface_tree = NULL;
+
+    if (view->server->grab_state.view == view) {
+        viv_server_clear_grab_state(view->server);
+    }
 }
 
 


### PR DESCRIPTION
This fixes a crash as the grab state currently continues to reference the view. This solution isn't that neat, but it will be easier to tidy it up once seats are properly abstracted in #71 