### PR TITLE
Additional input options

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -232,6 +232,9 @@ command = "amixer -q sset Master 3%+"
 # - left-handed : If true, switch left and right buttons. Defaults to false.
 # - natural-scroll : If true, switch the scrolling direction from default style (scroll down => go down)
 #                    to so-called "natural" style (scroll down => go up). Defaults to false.
+# - disable-with-typing : If true, disables the device while typing. Defaults to true
+# - click-method : Method for determining which button is being clicked.
+#                  One of "none", "areas" or "fingers". Defaults to "areas"
 
 [[libinput-config]]
 # Example libinput-config for a popular trackball:
@@ -241,6 +244,8 @@ scroll-button = 8
 middle-emulation = true
 left-handed = false
 natural-scroll = false
+disable-with-typing = true
+click-method = "areas"
 
 ### DEBUG ###
 # Vivarium debug options included for completion. You will want to leave these with their

--- a/config/config.toml
+++ b/config/config.toml
@@ -232,9 +232,9 @@ command = "amixer -q sset Master 3%+"
 # - left-handed : If true, switch left and right buttons. Defaults to false.
 # - natural-scroll : If true, switch the scrolling direction from default style (scroll down => go down)
 #                    to so-called "natural" style (scroll down => go up). Defaults to false.
-# - disable-with-typing : If true, disables the device while typing. Defaults to true
+# - disable-while-typing : If true, disables the device while typing. Defaults to false
 # - click-method : Method for determining which button is being clicked.
-#                  One of "none", "areas" or "fingers". Defaults to "areas"
+#                  One of "none", "areas" or "fingers". Defaults to "none"
 
 [[libinput-config]]
 # Example libinput-config for a popular trackball:
@@ -244,8 +244,8 @@ scroll-button = 8
 middle-emulation = true
 left-handed = false
 natural-scroll = false
-disable-with-typing = true
-click-method = "areas"
+disable-while-typing = false
+click-method = "none"
 
 ### DEBUG ###
 # Vivarium debug options included for completion. You will want to leave these with their

--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -128,6 +128,10 @@ struct viv_libinput_config the_libinput_configs[] = {
         .left_handed = 0,
         // Invert scroll direction
         .natural_scroll = 0,
+        // Disable while typing
+        .disable_with_typing = LIBINPUT_CONFIG_DWT_ENABLED,
+        // Method used for registering the type of click
+        .click_method = LIBINPUT_CONFIG_CLICK_METHOD_BUTTON_AREAS,
     },
     TERMINATE_LIBINPUT_CONFIG_LIST(),
 };

--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -128,10 +128,10 @@ struct viv_libinput_config the_libinput_configs[] = {
         .left_handed = 0,
         // Invert scroll direction
         .natural_scroll = 0,
-        // Disable while typing
-        .disable_with_typing = LIBINPUT_CONFIG_DWT_ENABLED,
-        // Method used for registering the type of click
-        .click_method = LIBINPUT_CONFIG_CLICK_METHOD_BUTTON_AREAS,
+        // Disable while typing (usually touchpad only)
+        .disable_while_typing = LIBINPUT_CONFIG_DWT_DISABLED,
+        // Method used for registering the type of click (usually touchpad only)
+        .click_method = LIBINPUT_CONFIG_CLICK_METHOD_NONE,
     },
     TERMINATE_LIBINPUT_CONFIG_LIST(),
 };

--- a/include/viv_config_types.h
+++ b/include/viv_config_types.h
@@ -30,6 +30,8 @@ struct viv_libinput_config {
     enum libinput_config_middle_emulation_state middle_emulation;
     int left_handed;
     int natural_scroll;
+    enum libinput_config_dwt_state disable_with_typing;
+    enum libinput_config_click_method click_method;
 };
 
 #endif

--- a/include/viv_config_types.h
+++ b/include/viv_config_types.h
@@ -30,7 +30,7 @@ struct viv_libinput_config {
     enum libinput_config_middle_emulation_state middle_emulation;
     int left_handed;
     int natural_scroll;
-    enum libinput_config_dwt_state disable_with_typing;
+    enum libinput_config_dwt_state disable_while_typing;
     enum libinput_config_click_method click_method;
 };
 

--- a/src/viv_input.c
+++ b/src/viv_input.c
@@ -13,7 +13,7 @@ static void configure_libinput_device(struct libinput_device *device, struct viv
     libinput_device_config_middle_emulation_set_enabled(device, config->middle_emulation);
     libinput_device_config_left_handed_set(device, config->left_handed);
     libinput_device_config_scroll_set_natural_scroll_enabled(device, config->natural_scroll);
-    libinput_device_config_dwt_set_enabled(device, config->disable_with_typing);
+    libinput_device_config_dwt_set_enabled(device, config->disable_while_typing);
     libinput_device_config_click_set_method(device, config->click_method);
 }
 

--- a/src/viv_input.c
+++ b/src/viv_input.c
@@ -13,6 +13,8 @@ static void configure_libinput_device(struct libinput_device *device, struct viv
     libinput_device_config_middle_emulation_set_enabled(device, config->middle_emulation);
     libinput_device_config_left_handed_set(device, config->left_handed);
     libinput_device_config_scroll_set_natural_scroll_enabled(device, config->natural_scroll);
+    libinput_device_config_dwt_set_enabled(device, config->disable_with_typing);
+    libinput_device_config_click_set_method(device, config->click_method);
 }
 
 static void try_configure_libinput_device(struct wlr_input_device *device, struct viv_libinput_config *libinput_configs) {

--- a/src/viv_toml_config.c
+++ b/src/viv_toml_config.c
@@ -94,7 +94,7 @@ static struct string_map_pair scroll_method_map[] = {
 
 static struct string_map_pair click_method_map[] = {
     {"none", LIBINPUT_CONFIG_CLICK_METHOD_NONE},
-    {"area", LIBINPUT_CONFIG_CLICK_METHOD_BUTTON_AREAS},
+    {"areas", LIBINPUT_CONFIG_CLICK_METHOD_BUTTON_AREAS},
     {"fingers", LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER},
     NULL_STRING_MAP_PAIR,
 };
@@ -476,13 +476,11 @@ static void parse_libinput_config_table(toml_table_t *libinput_table, struct viv
         libinput_config->natural_scroll = (uint32_t)natural_scroll.u.i;
     }
 
-    libinput_config->disable_with_typing = LIBINPUT_CONFIG_DWT_ENABLED;
-    toml_datum_t disable_with_typing = toml_bool_in(libinput_table, "disable-with-typing");
-    if (disable_with_typing.ok) {
-        libinput_config->disable_with_typing = disable_with_typing.u.i ? LIBINPUT_CONFIG_DWT_ENABLED : LIBINPUT_CONFIG_DWT_DISABLED;
+    toml_datum_t disable_while_typing = toml_bool_in(libinput_table, "disable-while-typing");
+    if (disable_while_typing.ok) {
+        libinput_config->disable_while_typing = disable_while_typing.u.i ? LIBINPUT_CONFIG_DWT_ENABLED : LIBINPUT_CONFIG_DWT_DISABLED;
     }
 
-    libinput_config->click_method = LIBINPUT_CONFIG_CLICK_METHOD_BUTTON_AREAS;
     toml_datum_t click_method = toml_string_in(libinput_table, "click-method");
     if (click_method.ok) {
         enum libinput_config_click_method click_method_enum;
@@ -496,9 +494,9 @@ static void parse_libinput_config_table(toml_table_t *libinput_table, struct viv
         free(click_method.u.s);
     }
 
-    wlr_log(WLR_DEBUG, "Parsed [[libinput-config]] for device \"%s\", scroll method %d, scroll button %d, middle emulation %d, left handed %d, natural scroll %d, disable with typing %d, click method %d",
+    wlr_log(WLR_DEBUG, "Parsed [[libinput-config]] for device \"%s\", scroll method %d, scroll button %d, middle emulation %d, left handed %d, natural scroll %d, disable while typing %d, click method %d",
             device_name.u.s, libinput_config->scroll_method, libinput_config->scroll_button,
-            libinput_config->middle_emulation, libinput_config->left_handed, libinput_config->natural_scroll, libinput_config->disable_with_typing, libinput_config->click_method);
+            libinput_config->middle_emulation, libinput_config->left_handed, libinput_config->natural_scroll, libinput_config->disable_while_typing, libinput_config->click_method);
 
     libinput_config->device_name = device_name.u.s;
 }

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -141,7 +141,7 @@ void test_config_toml_libinput_configs_match_defaults(void) {
         TEST_ASSERT_EQUAL(default_li_config.middle_emulation, load_li_config.middle_emulation);
         TEST_ASSERT_EQUAL(default_li_config.left_handed, load_li_config.left_handed);
         TEST_ASSERT_EQUAL(default_li_config.natural_scroll, load_li_config.natural_scroll);
-        TEST_ASSERT_EQUAL(default_li_config.disable_with_typing, load_li_config.disable_with_typing);
+        TEST_ASSERT_EQUAL(default_li_config.disable_while_typing, load_li_config.disable_while_typing);
         TEST_ASSERT_EQUAL(default_li_config.click_method, load_li_config.click_method);
 
         if (strlen(default_li_config.device_name) == 0) {

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -141,6 +141,8 @@ void test_config_toml_libinput_configs_match_defaults(void) {
         TEST_ASSERT_EQUAL(default_li_config.middle_emulation, load_li_config.middle_emulation);
         TEST_ASSERT_EQUAL(default_li_config.left_handed, load_li_config.left_handed);
         TEST_ASSERT_EQUAL(default_li_config.natural_scroll, load_li_config.natural_scroll);
+        TEST_ASSERT_EQUAL(default_li_config.disable_with_typing, load_li_config.disable_with_typing);
+        TEST_ASSERT_EQUAL(default_li_config.click_method, load_li_config.click_method);
 
         if (strlen(default_li_config.device_name) == 0) {
             break;


### PR DESCRIPTION
Adds the possibility to configure disabling the input device while typing and
allows for choosing the click method. Both of which are useful for touchpads

----

Two points to consider:

1. I wasn't sure if the way I set the default values is within expectations or not;
2. I couldn't figure out how to run the tests.