### PR TITLE
Support for wlr_output_power_management_v1

### DIFF
--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -82,6 +82,9 @@ struct viv_server {
 	struct wl_list outputs;
 	struct wl_listener new_output;
 
+    struct wlr_output_power_manager_v1 *output_power_manager;
+    struct wl_listener output_power_manager_set_mode;
+
     struct wl_list workspaces;
 
     pid_t bar_pid;

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -53,3 +53,27 @@ layer_shell_protocol_dep = declare_dependency(
   link_with : layer_shell_protocol,
   sources : layer_shell_include,
 )
+
+output_power_manager_src = custom_target(
+  'output_power_manager_protocol_c',
+  input : join_paths([local_protocols_dir, 'wlr-output-power-management-unstable-v1.xml']),
+  output : '@BASENAME@-protocol.c',
+  command : [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+)
+
+output_power_manager_include = custom_target(
+  'output_power_manager_protocol_h',
+  input : join_paths([local_protocols_dir, 'wlr-output-power-management-unstable-v1.xml']),
+  output : '@BASENAME@-protocol.h',
+  command : [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+)
+
+output_power_manager_protocol = static_library(
+  'output_power_manager_protocol',
+  [output_power_manager_src, output_power_manager_include],
+)
+
+output_power_manager_protocol_dep = declare_dependency(
+  link_with : output_power_manager_protocol,
+  sources : output_power_manager_include,
+)

--- a/protocols/xml/wlr-output-power-management-unstable-v1.xml
+++ b/protocols/xml/wlr-output-power-management-unstable-v1.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_output_power_management_unstable_v1">
+  <copyright>
+    Copyright © 2019 Purism SPC
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Control power management modes of outputs">
+    This protocol allows clients to control power management modes
+    of outputs that are currently part of the compositor space. The
+    intent is to allow special clients like desktop shells to power
+    down outputs when the system is idle.
+
+    To modify outputs not currently part of the compositor space see
+    wlr-output-management.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_output_power_manager_v1" version="1">
+    <description summary="manager to create per-output power management">
+      This interface is a manager that allows creating per-output power
+      management mode controls.
+    </description>
+
+    <request name="get_output_power">
+      <description summary="get a power management for an output">
+        Create a output power management mode control that can be used to
+        adjust the power management mode for a given output.
+      </description>
+      <arg name="id" type="new_id" interface="zwlr_output_power_v1"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_output_power_v1" version="1">
+    <description summary="adjust power management mode for an output">
+      This object offers requests to set the power management mode of
+      an output.
+    </description>
+
+    <enum name="mode">
+      <entry name="off" value="0"
+             summary="Output is turned off."/>
+      <entry name="on" value="1"
+             summary="Output is turned on, no power saving"/>
+    </enum>
+
+    <enum name="error">
+      <entry name="invalid_mode" value="1" summary="inexistent power save mode"/>
+    </enum>
+
+    <request name="set_mode">
+      <description summary="Set an outputs power save mode">
+        Set an output's power save mode to the given mode. The mode change
+        is effective immediately. If the output does not support the given
+        mode a failed event is sent.
+      </description>
+      <arg name="mode" type="uint" enum="mode" summary="the power save mode to set"/>
+    </request>
+
+    <event name="mode">
+      <description summary="Report a power management mode change">
+        Report the power management mode change of an output.
+
+        The mode event is sent after an output changed its power
+        management mode. The reason can be a client using set_mode or the
+        compositor deciding to change an output's mode.
+        This event is also sent immediately when the object is created
+        so the client is informed about the current power management mode.
+      </description>
+      <arg name="mode" type="uint" enum="mode"
+           summary="the output's new power management mode"/>
+    </event>
+
+    <event name="failed">
+      <description summary="object no longer valid">
+        This event indicates that the output power management mode control
+        is no longer valid. This can happen for a number of reasons,
+        including:
+        - The output doesn't support power management
+        - Another client already has exclusive power management mode control
+          for this output
+        - The output disappeared
+
+        Upon receiving this event, the client should destroy this object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy this power management">
+        Destroys the output power management mode control object.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/src/meson.build
+++ b/src/meson.build
@@ -36,6 +36,7 @@ viv_deps = [
     libinput_dep,
     xdg_shell_protocol_dep,
     layer_shell_protocol_dep,
+    output_power_manager_protocol_dep,
     tomlc99_dep,
     xcb_dep,
     pixman_dep,


### PR DESCRIPTION
Introduces support for the wlr_output_power_management_v1 protocol,
which allows for compatibility with power saving/dpms tools and utilities

----

I couldn't find a way to turn off my laptop's screen without closing the lid, so I implemented this.

An easy way to test is with `wlopm` (https://sr.ht/~leon_plickat/wlopm/) or a patched version of swaylock (https://github.com/gartnera/swaylock)