### PR TITLE
idle protocol

### DIFF
--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -64,6 +64,8 @@ struct viv_server {
 	struct viv_seat *default_seat;
     struct wl_list seats;  // server_link
 
+    struct wlr_idle *idle;
+
 	struct wl_listener new_input;
 
     struct wlr_xdg_output_manager_v1 *xdg_output_manager;

--- a/protocols/meson.build
+++ b/protocols/meson.build
@@ -77,3 +77,27 @@ output_power_manager_protocol_dep = declare_dependency(
   link_with : output_power_manager_protocol,
   sources : output_power_manager_include,
 )
+
+idle_src = custom_target(
+  'idle_protocol_c',
+  input : join_paths([local_protocols_dir, 'idle.xml']),
+  output : '@BASENAME@-protocol.c',
+  command : [wayland_scanner, 'private-code', '@INPUT@', '@OUTPUT@'],
+)
+
+idle_include = custom_target(
+  'idle_protocol_h',
+  input : join_paths([local_protocols_dir, 'idle.xml']),
+  output : '@BASENAME@-protocol.h',
+  command : [wayland_scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+)
+
+idle_protocol = static_library(
+  'idle_protocol',
+  [idle_src, idle_include],
+)
+
+idle_protocol_dep = declare_dependency(
+  link_with : idle_protocol,
+  sources : idle_include,
+)

--- a/protocols/xml/idle.xml
+++ b/protocols/xml/idle.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="idle">
+  <copyright><![CDATA[
+    Copyright (C) 2015 Martin Gräßlin
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 2.1 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+  ]]></copyright>
+  <interface  name="org_kde_kwin_idle" version="1">
+      <description summary="User idle time manager">
+        This interface allows to monitor user idle time on a given seat. The interface
+        allows to register timers which trigger after no user activity was registered
+        on the seat for a given interval. It notifies when user activity resumes.
+
+        This is useful for applications wanting to perform actions when the user is not
+        interacting with the system, e.g. chat applications setting the user as away, power
+        management features to dim screen, etc..
+      </description>
+      <request name="get_idle_timeout">
+        <arg name="id" type="new_id" interface="org_kde_kwin_idle_timeout"/>
+        <arg name="seat" type="object" interface="wl_seat"/>
+        <arg name="timeout" type="uint" summary="The idle timeout in msec"/>
+      </request>
+  </interface>
+  <interface name="org_kde_kwin_idle_timeout" version="1">
+      <request name="release" type="destructor">
+        <description summary="release the timeout object"/>
+      </request>
+      <request name="simulate_user_activity">
+          <description summary="Simulates user activity for this timeout, behaves just like real user activity on the seat"/>
+      </request>
+      <event name="idle">
+          <description summary="Triggered when there has not been any user activity in the requested idle time interval"/>
+      </event>
+      <event name="resumed">
+          <description summary="Triggered on the first user activity after an idle event"/>
+      </event>
+  </interface>
+</protocol>

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,6 +37,7 @@ viv_deps = [
     xdg_shell_protocol_dep,
     layer_shell_protocol_dep,
     output_power_manager_protocol_dep,
+    idle_protocol_dep,
     tomlc99_dep,
     xcb_dep,
     pixman_dep,

--- a/src/viv_seat.c
+++ b/src/viv_seat.c
@@ -2,6 +2,7 @@
 #include <wlr/types/wlr_cursor.h>
 #include <wlr/types/wlr_data_device.h>
 #include <wlr/types/wlr_seat.h>
+#include <wlr/types/wlr_idle.h>
 #include <wlr/util/edges.h>
 
 #include "viv_cursor.h"
@@ -64,6 +65,8 @@ static void keyboard_handle_key(struct wl_listener *listener, void *data) {
 	struct viv_server *server = keyboard->seat->server;
 	struct wlr_event_keyboard_key *event = data;
 	struct viv_seat *seat = keyboard->seat;
+
+    wlr_idle_notify_activity(seat->server->idle, seat->wlr_seat);
 
 	// Translate libinput keycode -> xkbcommon
 	uint32_t keycode = event->keycode + 8;
@@ -304,6 +307,8 @@ static void seat_cursor_motion(struct wl_listener *listener, void *data) {
     struct viv_seat *seat = wl_container_of(listener, seat, cursor_motion);
 	struct wlr_event_pointer_motion *event = data;
 
+    wlr_idle_notify_activity(seat->server->idle, seat->wlr_seat);
+
     // Pass the movement along (i.e. allow the cursor to actually move)
 	wlr_cursor_move(seat->cursor, event->device,
 			event->delta_x, event->delta_y);
@@ -317,6 +322,9 @@ static void seat_cursor_motion(struct wl_listener *listener, void *data) {
 static void seat_cursor_motion_absolute(struct wl_listener *listener, void *data) {
     struct viv_seat *seat = wl_container_of(listener, seat, cursor_motion_absolute);
 	struct wlr_event_pointer_motion_absolute *event = data;
+
+    wlr_idle_notify_activity(seat->server->idle, seat->wlr_seat);
+
 	wlr_cursor_warp_absolute(seat->cursor, event->device, event->x, event->y);
 	viv_cursor_process_cursor_motion(seat, event->time_msec);
 }
@@ -331,6 +339,9 @@ static void seat_cursor_button(struct wl_listener *listener, void *data) {
 	double sx, sy;
 	struct wlr_surface *surface;
 	struct viv_view *view = viv_server_view_at(server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy);
+
+    wlr_idle_notify_activity(seat->server->idle, seat->wlr_seat);
+
     // TODO: check for layer views to click on
 
 	if (event->state == WLR_BUTTON_RELEASED || !view) {
@@ -370,6 +381,9 @@ static void seat_cursor_button(struct wl_listener *listener, void *data) {
 static void seat_cursor_axis(struct wl_listener *listener, void *data) {
     struct viv_seat *seat = wl_container_of(listener, seat, cursor_axis);
 	struct wlr_event_pointer_axis *event = data;
+
+    wlr_idle_notify_activity(seat->server->idle, seat->wlr_seat);
+
 	/* Notify the client with pointer focus of the axis event. */
 	wlr_seat_pointer_notify_axis(seat->wlr_seat,
                                  event->time_msec, event->orientation, event->delta,

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -28,6 +28,7 @@
 #include <wlr/types/wlr_xdg_decoration_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
+#include <wlr/types/wlr_idle.h>
 #include <wlr/util/log.h>
 #include <wlr/version.h>
 #include <wordexp.h>
@@ -675,6 +676,8 @@ void viv_server_init(struct viv_server *server) {
 
     wl_list_init(&server->seats);
 	server->default_seat = viv_seat_create(server, DEFAULT_SEAT_NAME);
+
+    server->idle = wlr_idle_create(server->wl_display);
 
     struct wlr_server_decoration_manager *decoration_manager = wlr_server_decoration_manager_create(server->wl_display);
     server->decoration_manager = decoration_manager;


### PR DESCRIPTION
Implements support for the idle protocol, so that vivarium is compatible with
tools such as swayidle

----

Another simple one from my wishlist. I essentially looked at how sway first implemented this for inspiration. I left out cursor frame events as the description suggests it never happens in isolation. 

An easy way to test is to run `swayidle` with a low timeout:
e.g. `swayidle timeout 3 xeyes resume fire timeout 6 pcmanfm`
Then check that `xeyes` runs after 3 seconds of inactivity, that `fire` runs after activity is resumed, and that `pcmanfm` is run after 6 seconds.