### PR TITLE
Work around target box failure if a workspace's output is NULL

### DIFF
--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -244,6 +244,15 @@ bool viv_view_is_at(struct viv_view *view, double lx, double ly, struct wlr_surf
 void viv_view_set_target_box(struct viv_view *view, uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
     struct viv_workspace *workspace = view->workspace;
     struct viv_output *output = workspace->output;
+
+    if (!output) {
+        // If the view's workspace is not currently being displayed (e.g. it was switched
+        // away from in between a view init and map), interpret the target box as being on
+        // the active output.
+        // TODO: This will be obsolete if the target box abstraction is changed to be output-independent
+        output = workspace->server->active_output;
+    }
+
     struct wlr_output_layout_output *output_layout_output = wlr_output_layout_get(output->server->output_layout, output->wlr_output);
 
     int gap_width = output->server->config->gap_width;

--- a/src/viv_xwayland_shell.c
+++ b/src/viv_xwayland_shell.c
@@ -56,8 +56,7 @@ static void log_window_type_strings(struct wlr_xwayland_surface *surface) {
 }
 #endif
 
-/// Return true if the view looks like it should be floating. This is a poor proxy for proper window type inspection.
-/// TODO: Do proper window type inspection.
+/// Return true if the view looks like it should be floating according to its window type atoms.
 static bool guess_should_be_floating(struct viv_view *view) {
 
     struct wlr_xwayland_surface *surface = view->xwayland_surface;
@@ -154,8 +153,6 @@ static void event_xwayland_surface_map(struct wl_listener *listener, void *data)
 #endif
 
     if (guess_should_be_floating(view)) {
-        // Assume this is a popup or something, and just give it the size it wants
-        // TODO: There is probably a better/proper way to do this based on actual window type parsing
         view->is_floating = true;
 
         if (guess_should_have_no_borders(view)) {


### PR DESCRIPTION
This is by no means an ideal fix, but it should at least resolve an easily-triggered crash when leaving a workspace in between view init and map. I think this has particularly affected xwayland popups as they can appear/disappear a lot and often seem to have a long enough display between init and map for the user to perform actions.

Also created #95 to track that the target box handling isn't neat and needs a little rethink.