### PR TITLE
Fullscreen support

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -32,6 +32,9 @@ inactive-border-colour = [0.6, 0.6, 0.9, 1.0]  # rgba
 # Gap distance between windows
 gap-width = 0  # pixels
 
+# Allow views to go fullscreen
+allow-fullscreen = true
+
 # Desktop background colour. Note this is overridden by the [background] if set.
 clear-colour = [0.73, 0.73, 0.73, 1.0]
 

--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -222,6 +222,9 @@ static struct viv_config the_config = {
     // This may be overridden by the more sophisticated background settings below.
     .clear_colour = { 0.73, 0.73, 0.73, 1.0 },
 
+    // If false, acknowledge fullscreen requests, but don't act on them, keeping everything in windows
+    .allow_fullscreen = true,
+
     // Background configuration. Applies to all outputs. Requires `swaybg` to be installed.
     .background = {
         .colour = "#bbbbbb",  // note: this is overridden by .image if present

--- a/include/viv_mappable_functions.h
+++ b/include/viv_mappable_functions.h
@@ -40,6 +40,7 @@ union viv_mappable_payload;
     MACRO(shift_active_window_to_workspace, "Move active window to given workspace. Args: workspace_name (string)", char workspace_name[100];) \
     MACRO(shift_active_window_to_right_output, "Move active window to output to the right of current") \
     MACRO(shift_active_window_to_left_output, "Move active window to output to the left of current") \
+    MACRO(remove_fullscreen, "Unfullscreen the fullscreen view in the current workspace") \
     MACRO(close_window, "Close active window")                          \
     MACRO(make_window_main, "Move active window to first position in current layout") \
     MACRO(reload_config, "Reload the config.toml (warning: may have weird results, restart vivarium if possible)") \

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -251,8 +251,6 @@ struct viv_view {
 
     bool is_static;  /// true for e.g. X11 right click menus, signals that no borders should be drawn
                      /// and resizing/moving is not allowed
-
-    bool is_fullscreen;
 };
 
 struct viv_workspace {

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -189,6 +189,7 @@ struct viv_view_implementation {
     bool (*is_at)(struct viv_view *view, double lx, double ly, struct wlr_surface **surface, double *sx, double *sy);
     bool (*oversized)(struct viv_view *view);
     void (*inform_unrequested_fullscreen_change)(struct viv_view *view);
+    void (*grow_and_center_fullscreen)(struct viv_view *view);
 };
 
 struct viv_xdg_popup {

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -297,6 +297,8 @@ struct viv_config {
 
     int gap_width;
 
+    bool allow_fullscreen;
+
     char workspaces[MAX_NUM_WORKSPACES][MAX_WORKSPACE_NAME_LENGTH];
 
     struct {

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -243,12 +243,15 @@ struct viv_view {
 
     // Target positions, where the layout is trying to place the view
     struct wlr_box target_box;
+    struct wlr_box target_box_before_fullscreen;
 
     bool is_floating;
     float floating_width, floating_height;  /// width and height to be used if the view becomes floating
 
     bool is_static;  /// true for e.g. X11 right click menus, signals that no borders should be drawn
                      /// and resizing/moving is not allowed
+
+    bool is_fullscreen;
 };
 
 struct viv_workspace {

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -188,6 +188,7 @@ struct viv_view_implementation {
     void (*close)(struct viv_view *view);
     bool (*is_at)(struct viv_view *view, double lx, double ly, struct wlr_surface **surface, double *sx, double *sy);
     bool (*oversized)(struct viv_view *view);
+    void (*inform_unrequested_fullscreen_change)(struct viv_view *view);
 };
 
 struct viv_xdg_popup {
@@ -267,6 +268,7 @@ struct viv_workspace {
 
     struct wl_list views;  /// Ordered list of views associated with this workspace
     struct viv_view *active_view;  /// The view that currently has focus within the workspace
+    struct viv_view *fullscreen_view;
 
     struct wl_list server_link;
 };

--- a/include/viv_view.h
+++ b/include/viv_view.h
@@ -87,6 +87,10 @@ bool viv_view_is_at(struct viv_view *view, double lx, double ly, struct wlr_surf
 /// coordinates, with size reduced to make space for view borders and gaps.
 void viv_view_set_target_box(struct viv_view *view, uint32_t x, uint32_t y, uint32_t width, uint32_t height);
 
+/// Adjusts the target box so that it matches the surface exactly, taking into
+/// account borders and gaps
+void viv_view_match_target_box_with_surface_geometry(struct viv_view *view);
+
 /// Ensure that the given view is not active: if it is active, the active view in its
 /// workspace will be set to the next view (if present) or otherwise to NULL. This is
 /// useful for making sure focus goes somewhere when a view is unmapped.

--- a/include/viv_view.h
+++ b/include/viv_view.h
@@ -92,5 +92,8 @@ void viv_view_set_target_box(struct viv_view *view, uint32_t x, uint32_t y, uint
 /// useful for making sure focus goes somewhere when a view is unmapped.
 void viv_view_ensure_not_active_in_workspace(struct viv_view *view);
 
+/// Sets the view's fullscreen state
+void viv_view_set_fullscreen(struct viv_view *view, bool fullscreen);
+
 
 #endif

--- a/include/viv_view.h
+++ b/include/viv_view.h
@@ -92,8 +92,10 @@ void viv_view_set_target_box(struct viv_view *view, uint32_t x, uint32_t y, uint
 /// useful for making sure focus goes somewhere when a view is unmapped.
 void viv_view_ensure_not_active_in_workspace(struct viv_view *view);
 
-/// Sets the view's fullscreen state
-void viv_view_set_fullscreen(struct viv_view *view, bool fullscreen);
+/// Sets the view's fullscreen state. Returns true if the operatin was succesful, false otherwise
+bool viv_view_set_fullscreen(struct viv_view *view, bool fullscreen);
 
+/// Sets a view to non-fullscreen and informs the client if necessary
+void viv_view_force_remove_fullscreen(struct viv_view *view);
 
 #endif

--- a/src/viv_cursor.c
+++ b/src/viv_cursor.c
@@ -108,6 +108,8 @@ static void process_cursor_pass_through_to_surface(struct viv_seat *seat, uint32
     // Find the uppermost view or layer view under the cursor
     if ((layer_view = viv_server_layer_view_at(server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy, VIV_LAYER_MASK_OVERLAY))) {
     } else if (server->active_output && (view = server->active_output->current_workspace->fullscreen_view)) {
+        // Stop the search if there is a fullscreen view, even if a surface is not found, as we don't want to match views under the borders
+        viv_view_is_at(view, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy);
     } else if ((layer_view = viv_server_layer_view_at(server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy, VIV_LAYER_MASK_TOP))) {
     } else if ((view = viv_server_view_at(server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy))) {
     } else if ((layer_view = viv_server_layer_view_at(server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy, VIV_LAYER_MASK_BOTTOM))) {

--- a/src/viv_cursor.c
+++ b/src/viv_cursor.c
@@ -107,6 +107,7 @@ static void process_cursor_pass_through_to_surface(struct viv_seat *seat, uint32
 
     // Find the uppermost view or layer view under the cursor
     if ((layer_view = viv_server_layer_view_at(server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy, VIV_LAYER_MASK_OVERLAY))) {
+    } else if (server->active_output && (view = server->active_output->current_workspace->fullscreen_view)) {
     } else if ((layer_view = viv_server_layer_view_at(server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy, VIV_LAYER_MASK_TOP))) {
     } else if ((view = viv_server_view_at(server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy))) {
     } else if ((layer_view = viv_server_layer_view_at(server, seat->cursor->x, seat->cursor->y, &surface, &sx, &sy, VIV_LAYER_MASK_BOTTOM))) {

--- a/src/viv_layout.c
+++ b/src/viv_layout.c
@@ -320,7 +320,7 @@ void viv_layout_apply(struct viv_workspace *workspace, uint32_t width, uint32_t 
     struct viv_view *view;
     wl_list_for_each(view, &workspace->views, workspace_link) {
         // Pull out only the non-floating views to be laid out
-        if (view->is_floating || view->is_fullscreen) {
+        if (view->is_floating || (view->workspace->fullscreen_view == view)) {
             continue;
         }
         viv_wl_array_append_view(&views_array, view);

--- a/src/viv_layout.c
+++ b/src/viv_layout.c
@@ -320,7 +320,7 @@ void viv_layout_apply(struct viv_workspace *workspace, uint32_t width, uint32_t 
     struct viv_view *view;
     wl_list_for_each(view, &workspace->views, workspace_link) {
         // Pull out only the non-floating views to be laid out
-        if (view->is_floating) {
+        if (view->is_floating || view->is_fullscreen) {
             continue;
         }
         viv_wl_array_append_view(&views_array, view);

--- a/src/viv_mappable_functions.c
+++ b/src/viv_mappable_functions.c
@@ -140,7 +140,7 @@ void viv_mappable_float_window(struct viv_workspace *workspace, union viv_mappab
         return;
     }
 
-    if (view->is_fullscreen) {
+    if (view->workspace->fullscreen_view == view) {
         wlr_log(WLR_DEBUG, "Cannot float active view, it is fullscreen");
         return;
     }

--- a/src/viv_mappable_functions.c
+++ b/src/viv_mappable_functions.c
@@ -140,6 +140,11 @@ void viv_mappable_float_window(struct viv_workspace *workspace, union viv_mappab
         return;
     }
 
+    if (view->is_fullscreen) {
+        wlr_log(WLR_DEBUG, "Cannot float active view, it is fullscreen");
+        return;
+    }
+
     viv_view_damage(view);
 
     wl_list_remove(&view->workspace_link);

--- a/src/viv_mappable_functions.c
+++ b/src/viv_mappable_functions.c
@@ -276,6 +276,19 @@ void viv_mappable_shift_active_window_to_workspace(struct viv_workspace *workspa
     viv_view_shift_to_workspace(cur_view, target_workspace);
 }
 
+void viv_mappable_remove_fullscreen(struct viv_workspace *workspace, union viv_mappable_payload payload) {
+    char *name = payload.shift_active_window_to_workspace.workspace_name;
+    wlr_log(WLR_DEBUG, "Mappable remove_workspace_fullscreen with name %s", name);
+
+    if (!workspace->fullscreen_view) {
+        wlr_log(WLR_DEBUG, "No fullscreen view, cannot remove attribute from workspace %s", name);
+        return;
+    }
+
+    viv_view_force_remove_fullscreen(workspace->fullscreen_view);
+    viv_workspace_mark_for_relayout(workspace);
+}
+
 void viv_mappable_switch_to_workspace(struct viv_workspace *workspace, union viv_mappable_payload payload) {
     UNUSED(workspace);
 

--- a/src/viv_render.c
+++ b/src/viv_render.c
@@ -260,7 +260,7 @@ static void viv_render_xdg_view(struct wlr_renderer *renderer, struct viv_view *
     bool is_active_on_current_output = ((output == output->server->active_output) &
                                         (view == view->workspace->active_view));
     bool is_active = is_grabbed || is_active_on_current_output;
-    if ((view->is_floating || !view->workspace->active_layout->no_borders) && !view->is_fullscreen) {
+    if ((view->is_floating || !view->workspace->active_layout->no_borders) && (view->workspace->fullscreen_view != view )) {
         render_borders(view, output, damage, is_active);
     }
 
@@ -325,7 +325,7 @@ static void viv_render_xwayland_view(struct wlr_renderer *renderer, struct viv_v
                                         (view == view->workspace->active_view));
     bool is_active = is_grabbed || is_active_on_current_output;
     if (!view->is_static &&
-        !view->is_fullscreen &&
+        (view->workspace->fullscreen_view != view) &&
         (view->is_floating || !view->workspace->active_layout->no_borders)) {
         render_borders(view, output, damage, is_active);
     }

--- a/src/viv_render.c
+++ b/src/viv_render.c
@@ -514,10 +514,12 @@ void viv_render_output(struct wlr_renderer *renderer, struct viv_output *output)
                 viv_render_layer_view(renderer, layer_view, output, &damage);
             }
         }
-        wl_list_for_each_reverse(layer_view, &output->layer_views, output_link) {
-            if (viv_layer_is(layer_view, ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY)) {
-                viv_render_layer_view(renderer, layer_view, output, &damage);
-            }
+    }
+
+    // Overlays on top of fullscreen views
+    wl_list_for_each_reverse(layer_view, &output->layer_views, output_link) {
+        if (viv_layer_is(layer_view, ZWLR_LAYER_SHELL_V1_LAYER_OVERLAY)) {
+            viv_render_layer_view(renderer, layer_view, output, &damage);
         }
     }
 

--- a/src/viv_seat.c
+++ b/src/viv_seat.c
@@ -227,7 +227,7 @@ void viv_seat_begin_interactive(struct viv_seat *seat, struct viv_view *view, en
 	 * compositor stops propegating pointer events to clients and instead
 	 * consumes them itself, to move or resize windows. */
 	struct wlr_surface *focused_surface = seat->wlr_seat->pointer_state.focused_surface;
-	if (viv_view_get_toplevel_surface(view) != focused_surface || view->is_fullscreen) {
+	if (viv_view_get_toplevel_surface(view) != focused_surface || (view->workspace->fullscreen_view == view)) {
 		/* Deny move/resize requests from unfocused and fullscreen clients. */
 		return;
 	}

--- a/src/viv_seat.c
+++ b/src/viv_seat.c
@@ -227,8 +227,8 @@ void viv_seat_begin_interactive(struct viv_seat *seat, struct viv_view *view, en
 	 * compositor stops propegating pointer events to clients and instead
 	 * consumes them itself, to move or resize windows. */
 	struct wlr_surface *focused_surface = seat->wlr_seat->pointer_state.focused_surface;
-	if (viv_view_get_toplevel_surface(view) != focused_surface) {
-		/* Deny move/resize requests from unfocused clients. */
+	if (viv_view_get_toplevel_surface(view) != focused_surface || view->is_fullscreen) {
+		/* Deny move/resize requests from unfocused and fullscreen clients. */
 		return;
 	}
 	seat->grab_state.view = view;

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -136,8 +136,11 @@ struct viv_view *viv_server_view_at(
         return NULL;
     }
 
-    // Fullscreen view has priority
+    // Fullscreen view should always be blocking all other views
     if (active_output->current_workspace->fullscreen_view) {
+      if (!viv_view_is_at(active_output->current_workspace->fullscreen_view, lx, ly, surface, sx, sy)) {
+          *surface = NULL;
+      }
       return active_output->current_workspace->fullscreen_view;
     }
 

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -136,6 +136,11 @@ struct viv_view *viv_server_view_at(
         return NULL;
     }
 
+    // Fullscreen view has priority
+    if (active_output->current_workspace->fullscreen_view) {
+      return active_output->current_workspace->fullscreen_view;
+    }
+
 	struct viv_view *view;
     // Try floating views first
 	wl_list_for_each(view, &active_output->current_workspace->views, workspace_link) {

--- a/src/viv_toml_config.c
+++ b/src/viv_toml_config.c
@@ -599,6 +599,7 @@ void load_file_as_toml_config(FILE *fp, struct viv_config *config) {
     parse_config_array_fixed_size_float_float(root, "global-config", "inactive-border-colour", 4, config->inactive_border_colour);
     parse_config_int(root, "global-config", "gap-width", &config->gap_width);
     parse_config_array_fixed_size_float_float(root, "global-config", "clear-colour", 4, config->clear_colour);
+    parse_config_bool(root, "global-config", "allow-fullscreen", &config->allow_fullscreen);
 
     toml_array_t *workspace_names = toml_array_in(global_config, "workspace-names");
     if (toml_array_kind(workspace_names) != 'v') {

--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -362,7 +362,7 @@ bool viv_view_set_fullscreen(struct viv_view *view, bool fullscreen) {
     char view_name[VIEW_NAME_LEN];
     viv_view_get_string_identifier(view, view_name, VIEW_NAME_LEN);
     if (!view->mapped && fullscreen) {
-        wlr_log(WLR_DEBUG, "View %s requesting fullscreen before being mapped");
+        wlr_log(WLR_DEBUG, "View %s requesting fullscreen before being mapped", view_name);
     }
     if (fullscreen && view->workspace->fullscreen_view) {
         wlr_log(WLR_DEBUG,

--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -329,8 +329,6 @@ void viv_view_match_target_box_with_surface_geometry(struct viv_view *view) {
         gap_width = 0u;
         border_width = 0u;
     }
-    wlr_log(WLR_DEBUG, "MATCH %dx%d->%dx%d", view->target_box.width,
-        view->target_box.height, box.width, box.height);
 
     view->target_box.width = box.width + 2 * border_width + 2 * gap_width;
     view->target_box.height = box.height + 2 * border_width + 2 * gap_width;

--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -332,7 +332,7 @@ bool viv_view_set_fullscreen(struct viv_view *view, bool fullscreen) {
 
     char view_name[VIEW_NAME_LEN];
     viv_view_get_string_identifier(view, view_name, VIEW_NAME_LEN);
-    if (!view->mapped) {
+    if (!view->mapped && fullscreen) {
         wlr_log(WLR_DEBUG, "Preventing view %s from going fullscreen. Unmapped", view_name);
         return false;
     }

--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -260,7 +260,7 @@ void viv_view_set_target_box(struct viv_view *view, uint32_t x, uint32_t y, uint
     int ox = output_layout_output->x;
     int oy = output_layout_output->y;
     if (!output->current_workspace->active_layout->ignore_excluded_regions &&
-        !view->is_floating) {
+        !view->is_floating && !view->is_fullscreen) {
         ox += output->excluded_margin.left;
         oy += output->excluded_margin.top;
     }
@@ -275,7 +275,7 @@ void viv_view_set_target_box(struct viv_view *view, uint32_t x, uint32_t y, uint
 
     int border_width = output->server->config->border_width;
     if (output->current_workspace->active_layout->no_borders ||
-        view->is_static) {
+        view->is_static || view->is_fullscreen) {
         border_width = 0u;
     }
 
@@ -297,4 +297,25 @@ void viv_view_ensure_not_active_in_workspace(struct viv_view *view) {
             workspace->active_view = NULL;
         }
     }
+}
+
+void viv_view_set_fullscreen(struct viv_view *view, bool fullscreen) {
+    if (view->is_fullscreen == fullscreen) {
+        return;
+    }
+
+    view->is_fullscreen = fullscreen;
+
+    if (view->is_fullscreen) {
+        int width = view->workspace->output->wlr_output->width;
+        int height = view->workspace->output->wlr_output->height;
+        view->target_box_before_fullscreen = view->target_box;
+        viv_view_set_target_box(view, 0, 0, width, height);
+    }
+    else if (view->is_floating) {
+        struct wlr_box *box = &view->target_box_before_fullscreen;
+        viv_view_set_target_box(view, box->x, box->y, box->width, box->height);
+    }
+
+    viv_workspace_mark_for_relayout(view->workspace);
 }

--- a/src/viv_workspace.c
+++ b/src/viv_workspace.c
@@ -257,6 +257,15 @@ void viv_workspace_add_view(struct viv_workspace *workspace, struct viv_view *vi
         wl_list_insert(&workspace->views, &view->workspace_link);
     }
 
+    if (view->is_fullscreen) {
+        if (workspace->fullscreen_view && (workspace->fullscreen_view != view)) {
+            wlr_log(WLR_DEBUG, "Tried to add fullscreen view to a workspace that already another one. Adding as non-fullscreen");
+            viv_view_force_remove_fullscreen(view);
+        } else {
+            workspace->fullscreen_view = view;
+        }
+    }
+
 	viv_view_focus(view, viv_view_get_toplevel_surface(view));
 
     viv_workspace_mark_for_relayout(workspace);

--- a/src/viv_workspace.c
+++ b/src/viv_workspace.c
@@ -266,7 +266,9 @@ void viv_workspace_add_view(struct viv_workspace *workspace, struct viv_view *vi
         }
     }
 
-	viv_view_focus(view, viv_view_get_toplevel_surface(view));
+    if (!workspace->fullscreen_view || (workspace->fullscreen_view == view)) {
+        viv_view_focus(view, viv_view_get_toplevel_surface(view));
+    }
 
     viv_workspace_mark_for_relayout(workspace);
 }

--- a/src/viv_workspace.c
+++ b/src/viv_workspace.c
@@ -257,7 +257,7 @@ void viv_workspace_add_view(struct viv_workspace *workspace, struct viv_view *vi
         wl_list_insert(&workspace->views, &view->workspace_link);
     }
 
-    if (view->is_fullscreen) {
+    if (view->workspace->fullscreen_view == view) {
         if (workspace->fullscreen_view && (workspace->fullscreen_view != view)) {
             wlr_log(WLR_DEBUG, "Tried to add fullscreen view to a workspace that already another one. Adding as non-fullscreen");
             viv_view_force_remove_fullscreen(view);

--- a/src/viv_xdg_shell.c
+++ b/src/viv_xdg_shell.c
@@ -306,7 +306,7 @@ static bool implementation_oversized(struct viv_view *view) {
 }
 
 static void implementation_inform_unrequested_fullscreen_change(struct viv_view *view) {
-    view->xdg_surface->toplevel->server_pending.fullscreen = view->is_fullscreen;
+    view->xdg_surface->toplevel->server_pending.fullscreen = (view->workspace->fullscreen_view == view);
     wlr_xdg_surface_schedule_configure(view->xdg_surface);
 }
 

--- a/src/viv_xwayland_shell.c
+++ b/src/viv_xwayland_shell.c
@@ -203,7 +203,7 @@ static void event_xwayland_surface_map(struct wl_listener *listener, void *data)
 
     if (view->server->config->allow_fullscreen) {
         viv_view_set_fullscreen(view, surface->fullscreen);
-        wlr_xwayland_surface_set_fullscreen(surface, view->is_fullscreen);
+        wlr_xwayland_surface_set_fullscreen(surface, view->workspace->fullscreen_view == view);
     }
 
     view->surface_tree = viv_surface_tree_root_create(view->server, view->xwayland_surface->surface, &add_xwayland_view_global_coords, view);
@@ -251,7 +251,7 @@ static void event_xwayland_request_fullscreen(struct wl_listener *listener, void
     }
 
     viv_view_set_fullscreen(view, surface->fullscreen);
-    wlr_xwayland_surface_set_fullscreen(surface, view->is_fullscreen);
+    wlr_xwayland_surface_set_fullscreen(surface, view->workspace->fullscreen_view == view );
 }
 
 static void event_xwayland_surface_destroy(struct wl_listener *listener, void *data) {
@@ -342,7 +342,7 @@ static bool implementation_oversized(struct viv_view *view) {
 }
 
 static void implementation_inform_unrequested_fullscreen_change(struct viv_view *view) {
-    wlr_xwayland_surface_set_fullscreen(view->xwayland_surface, view->is_fullscreen);
+    wlr_xwayland_surface_set_fullscreen(view->xwayland_surface, view->workspace->fullscreen_view == view);
 }
 
 static struct viv_view_implementation xwayland_view_implementation = {

--- a/tests/test_config.c
+++ b/tests/test_config.c
@@ -58,6 +58,8 @@ void test_config_toml_static_options_match_defaults(void) {
 
     TEST_ASSERT_CONFIG_EQUAL(gap_width);
 
+    TEST_ASSERT_CONFIG_EQUAL(allow_fullscreen);
+
     TEST_ASSERT_CONFIG_EQUAL_FLOAT_ARRAY(clear_colour, RGBA_NUM_VALUES);
 
     TEST_ASSERT_CONFIG_EQUAL_STRING(background.colour);


### PR DESCRIPTION
Introduces support for fullscreen requests and initializations in both xdg and xwayland

----

Not implemented: handling full screen requests to specific outputs. We always go with the one the view is already in.

Testing:
`mpv` is very versatile for this. Try all of the combinations:
1. Fullscreen start, wayland (`-fs -vo wlshm`);
2. Non-fullscreen start, wayland (`-vo wlshm`);
3. Fullscreen start, X (`-fs -vo x11`);
4. Non-fullscreen start, X (`-vo x11`).

Toggle to and from fullscreen a few times. Move to other workspaces, try floating fullscreen view, try resizing, dragging...

Also try making a floating window fullscreen and back. It should remember the old geometry.