### PR TITLE
Idle inhibit protocol

### DIFF
--- a/include/viv_server.h
+++ b/include/viv_server.h
@@ -47,4 +47,6 @@ void viv_server_clear_view_from_grab_state(struct viv_server *server, struct viv
 
 /// True if the given view is currently grabbed by any seat, else false
 bool viv_server_any_seat_grabs(struct viv_server *server, struct viv_view *view);
+
+void viv_server_update_idle_inhibitor_state(struct viv_server *server);
 #endif

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -5,6 +5,7 @@
 #include <wlr/types/wlr_box.h>
 #include <wlr/types/wlr_output_management_v1.h>
 #include <wlr/types/wlr_xdg_shell.h>
+#include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_layer_shell_v1.h>
 #include <xkbcommon/xkbcommon.h>
 
@@ -65,6 +66,10 @@ struct viv_server {
     struct wl_list seats;  // server_link
 
     struct wlr_idle *idle;
+
+    struct wlr_idle_inhibit_manager_v1 *idle_inhibit_manager;
+    struct wl_listener new_idle_inhibitor;
+    struct wl_listener destroy_idle_inhibitor;
 
 	struct wl_listener new_input;
 

--- a/src/viv_workspace.c
+++ b/src/viv_workspace.c
@@ -4,6 +4,7 @@
 #include "viv_cursor.h"
 #include "viv_layout.h"
 #include "viv_output.h"
+#include "viv_server.h"
 #include "viv_types.h"
 #include "viv_view.h"
 #include "viv_wl_list_utils.h"
@@ -225,6 +226,9 @@ void viv_workspace_do_layout(struct viv_workspace *workspace) {
     struct timespec now;
     clock_gettime(CLOCK_MONOTONIC, &now);
     viv_cursor_reset_focus(workspace->server, (int64_t)now.tv_sec * 1000 + now.tv_nsec / 1000000);
+
+    // Inhibitor visibility may have changed
+    viv_server_update_idle_inhibitor_state(workspace->server);
 
     workspace->was_laid_out = true;
 


### PR DESCRIPTION
Introduces support for the idle inhibit protocol (idle-inhibit-unstable-v1).
According to the protocol description, visible surfaces can prevent displays
from entering the idle state.  The introduced code supports xdg, xwayland,
and layer surfaces.  Though, in practice, this is limited to what wlroots
signals (i.e. no xwayland)


----

I have been using this with no issues so far.
An easy way to test is to fire up swayidle with a low timeout:
`swayidle timeout 5 xeyes`

Make sure it's working.
Then launch `mpv`, make sure it doesn't go idle.
Then move `mpv` to another workspace, make sure it goes idle.
Then switch to that workspace, make sure it doesn't go idle.
Then move it back, ensure it does.
Then switch back, ensure it doesn't.
Then close it, ensure it does.

I am open to alternatives to updating the state on relayout. The idea is that if it's done late in the changes-to-views workflows, the code can be simplified and only call it in one place.