### PR TITLE
Fix refocusing when shifting views to other workspaces

### DIFF
--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -103,7 +103,9 @@ void viv_view_shift_to_workspace(struct viv_view *view, struct viv_workspace *wo
     wl_list_insert(&workspace->views, &view->workspace_link);
 
     if (next_view != NULL) {
-        viv_view_focus(next_view, view->xdg_surface->surface);
+        viv_view_focus(next_view, NULL);
+    } else {
+        viv_view_clear_all_focus(view->server);
     }
 
     viv_workspace_mark_for_relayout(cur_workspace);


### PR DESCRIPTION
- If the workspace ends up empty, focus is now removed;
- Otherwise, focus is passed onto the next view

----

This addresses some issues I have been having where the focus ends up on unexpected views

There is some overlap with the `fullscreen` PR, but the merge/rebase should be trivial