### PR TITLE
Add tap to click config support

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -235,9 +235,10 @@ command = "amixer -q sset Master 3%+"
 # - left-handed : If true, switch left and right buttons. Defaults to false.
 # - natural-scroll : If true, switch the scrolling direction from default style (scroll down => go down)
 #                    to so-called "natural" style (scroll down => go up). Defaults to false.
-# - disable-while-typing : If true, disables the device while typing. Defaults to false
+# - disable-while-typing : If true, disables the device while typing. Defaults to false.
 # - click-method : Method for determining which button is being clicked.
 #                  One of "none", "areas" or "fingers". Defaults to "none"
+# - tap-to-click : If true, enable tap to click on touchpads and similar devices. Defaults to true.
 
 [[libinput-config]]
 # Example libinput-config for a popular trackball:
@@ -249,6 +250,7 @@ left-handed = false
 natural-scroll = false
 disable-while-typing = false
 click-method = "none"
+tap-to-click = true
 
 ### DEBUG ###
 # Vivarium debug options included for completion. You will want to leave these with their

--- a/config/config.toml
+++ b/config/config.toml
@@ -239,6 +239,8 @@ command = "amixer -q sset Master 3%+"
 # - click-method : Method for determining which button is being clicked.
 #                  One of "none", "areas" or "fingers". Defaults to "none"
 # - tap-to-click : If true, enable tap to click on touchpads and similar devices. Defaults to true.
+# - tap-button-map : Map from number of fingers (1,2,3) to clicked button when using tap-to-click.
+#                    One of "left-right-middle" or "left-middle-right", other options not supported.
 
 [[libinput-config]]
 # Example libinput-config for a popular trackball:
@@ -251,6 +253,8 @@ natural-scroll = false
 disable-while-typing = false
 click-method = "none"
 tap-to-click = true
+tap-button-map = "left-right-middle"
+
 
 ### DEBUG ###
 # Vivarium debug options included for completion. You will want to leave these with their

--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -133,7 +133,9 @@ struct viv_libinput_config the_libinput_configs[] = {
         // Method used for registering the type of click (usually touchpad only)
         .click_method = LIBINPUT_CONFIG_CLICK_METHOD_NONE,
         // Enable tap to click (usually touchpad only)
-        .tap_to_click = LIBINPUT_CONFIG_TAP_ENABLED
+        .tap_to_click = LIBINPUT_CONFIG_TAP_ENABLED,
+        // Config used for interpreting tap to click, i.e. mapping from number of fingers to click button
+        .tap_button_map = LIBINPUT_CONFIG_TAP_MAP_LRM,
     },
     TERMINATE_LIBINPUT_CONFIG_LIST(),
 };

--- a/config/viv_config.h
+++ b/config/viv_config.h
@@ -132,6 +132,8 @@ struct viv_libinput_config the_libinput_configs[] = {
         .disable_while_typing = LIBINPUT_CONFIG_DWT_DISABLED,
         // Method used for registering the type of click (usually touchpad only)
         .click_method = LIBINPUT_CONFIG_CLICK_METHOD_NONE,
+        // Enable tap to click (usually touchpad only)
+        .tap_to_click = LIBINPUT_CONFIG_TAP_ENABLED
     },
     TERMINATE_LIBINPUT_CONFIG_LIST(),
 };

--- a/include/viv_config_types.h
+++ b/include/viv_config_types.h
@@ -33,6 +33,7 @@ struct viv_libinput_config {
     enum libinput_config_dwt_state disable_while_typing;
     enum libinput_config_click_method click_method;
     enum libinput_config_tap_state tap_to_click;
+    enum libinput_config_tap_button_map tap_button_map;
 };
 
 #endif

--- a/include/viv_config_types.h
+++ b/include/viv_config_types.h
@@ -32,6 +32,7 @@ struct viv_libinput_config {
     int natural_scroll;
     enum libinput_config_dwt_state disable_while_typing;
     enum libinput_config_click_method click_method;
+    enum libinput_config_tap_state tap_to_click;
 };
 
 #endif

--- a/src/viv_input.c
+++ b/src/viv_input.c
@@ -15,6 +15,7 @@ static void configure_libinput_device(struct libinput_device *device, struct viv
     libinput_device_config_scroll_set_natural_scroll_enabled(device, config->natural_scroll);
     libinput_device_config_dwt_set_enabled(device, config->disable_while_typing);
     libinput_device_config_click_set_method(device, config->click_method);
+    libinput_device_config_tap_set_enabled(device, config->tap_to_click);
 }
 
 static void try_configure_libinput_device(struct wlr_input_device *device, struct viv_libinput_config *libinput_configs) {

--- a/src/viv_input.c
+++ b/src/viv_input.c
@@ -16,6 +16,7 @@ static void configure_libinput_device(struct libinput_device *device, struct viv
     libinput_device_config_dwt_set_enabled(device, config->disable_while_typing);
     libinput_device_config_click_set_method(device, config->click_method);
     libinput_device_config_tap_set_enabled(device, config->tap_to_click);
+    libinput_device_config_tap_set_button_map(device, config->tap_button_map);
 }
 
 static void try_configure_libinput_device(struct wlr_input_device *device, struct viv_libinput_config *libinput_configs) {

--- a/src/viv_toml_config.c
+++ b/src/viv_toml_config.c
@@ -515,6 +515,17 @@ static void parse_libinput_config_table(toml_table_t *libinput_table, struct viv
         free(click_method.u.s);
     }
 
+    toml_datum_t tap_to_click = toml_bool_in(libinput_table, "tap-to-click");
+    if (tap_to_click.ok) {
+        int do_tap_to_click = (int)tap_to_click.u.i;
+        // tap-to-click has only two (boolean) options but for some reason (future
+        // extension?) is abstracted as an enum, we provide a boolean interface for
+        // simplicity
+        enum libinput_config_tap_state tap_to_click_state = (
+            do_tap_to_click ? LIBINPUT_CONFIG_TAP_ENABLED : LIBINPUT_CONFIG_TAP_DISABLED);
+        libinput_config->tap_to_click = tap_to_click_state;
+    }
+
     wlr_log(WLR_DEBUG, "Parsed [[libinput-config]] for device \"%s\", scroll method %d, scroll button %d, middle emulation %d, left handed %d, natural scroll %d, disable while typing %d, click method %d",
             device_name.u.s, libinput_config->scroll_method, libinput_config->scroll_button,
             libinput_config->middle_emulation, libinput_config->left_handed, libinput_config->natural_scroll, libinput_config->disable_while_typing, libinput_config->click_method);

--- a/src/viv_toml_config.c
+++ b/src/viv_toml_config.c
@@ -99,6 +99,12 @@ static struct string_map_pair click_method_map[] = {
     NULL_STRING_MAP_PAIR,
 };
 
+static struct string_map_pair tap_button_map_map[] = {
+    {"left-right-middle", LIBINPUT_CONFIG_TAP_MAP_LRM},
+    {"left-middle-right", LIBINPUT_CONFIG_TAP_MAP_LMR},
+    NULL_STRING_MAP_PAIR,
+};
+
 static struct string_map_pair damage_tracking_mode_map[] = {
     {"none", VIV_DAMAGE_TRACKING_NONE},
     {"frame", VIV_DAMAGE_TRACKING_FRAME},
@@ -524,6 +530,19 @@ static void parse_libinput_config_table(toml_table_t *libinput_table, struct viv
         enum libinput_config_tap_state tap_to_click_state = (
             do_tap_to_click ? LIBINPUT_CONFIG_TAP_ENABLED : LIBINPUT_CONFIG_TAP_DISABLED);
         libinput_config->tap_to_click = tap_to_click_state;
+    }
+
+    toml_datum_t tap_button_map = toml_string_in(libinput_table, "tap-button-map");
+    if (tap_button_map.ok) {
+        enum libinput_config_tap_button_map tap_button_map_enum;
+        bool success = look_up_string_in_map(tap_button_map.u.s, tap_button_map_map, &tap_button_map_enum);
+        if (!success) {
+            EXIT_WITH_FORMATTED_MESSAGE("Error parsing [[libinput-config]] for device \"%s\": click-method \"%s\" not recognised",
+                                        device_name.u.s, tap_button_map.u.s);
+        } else {
+            libinput_config->tap_button_map = tap_button_map_enum;
+        }
+        free(tap_button_map.u.s);
     }
 
     wlr_log(WLR_DEBUG, "Parsed [[libinput-config]] for device \"%s\", scroll method %d, scroll button %d, middle emulation %d, left handed %d, natural scroll %d, disable while typing %d, click method %d",


### PR DESCRIPTION
Resolves #116 

As pointed out by @flaviozavan on #116, tap to click simply wasn't configured by vivarium. That's an omission on my part, I thought I'd caught the minimal set of libinput functionality to cover this kind of common configuration but apparently not.

This PR adds a config option to enable tap to click as well as to make the basic left-right-middle or left-middle-right config choice.