### PR TITLE
Primary selection protocol

### DIFF
--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -379,6 +379,8 @@ struct viv_seat {
     struct wl_listener start_drag;
     struct wl_listener drag_destroy;
 
+    struct wl_listener request_set_primary_selection;
+
     struct wl_list server_link;
 };
 

--- a/src/viv_seat.c
+++ b/src/viv_seat.c
@@ -4,6 +4,7 @@
 #include <wlr/types/wlr_seat.h>
 #include <wlr/types/wlr_idle.h>
 #include <wlr/util/edges.h>
+#include <wlr/types/wlr_primary_selection.h>
 
 #include "viv_cursor.h"
 #include "viv_config_support.h"
@@ -400,6 +401,12 @@ static void seat_cursor_frame(struct wl_listener *listener, void *data) {
 	wlr_seat_pointer_notify_frame(seat->wlr_seat);
 }
 
+static void seat_request_set_primary_selection(struct wl_listener *listener, void *data) {
+    struct viv_seat *seat = wl_container_of(listener, seat, request_set_primary_selection);
+    struct wlr_seat_request_set_primary_selection_event *event = data;
+    wlr_seat_set_primary_selection(seat->wlr_seat, event->source, event->serial);
+}
+
 struct viv_seat *viv_seat_create(struct viv_server *server, char *name) {
     struct wl_display *wl_display = server->wl_display;
 
@@ -445,6 +452,12 @@ struct viv_seat *viv_seat_create(struct viv_server *server, char *name) {
 	wl_signal_add(&seat->cursor->events.axis, &seat->cursor_axis);
 	seat->cursor_frame.notify = seat_cursor_frame;
 	wl_signal_add(&seat->cursor->events.frame, &seat->cursor_frame);
+
+
+    seat->request_set_primary_selection.notify = seat_request_set_primary_selection;
+    wl_signal_add(&seat->wlr_seat->events.request_set_primary_selection,
+        &seat->request_set_primary_selection);
+
 
     return seat;
 }

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -31,6 +31,7 @@
 #include <wlr/types/wlr_idle.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
+#include <wlr/types/wlr_primary_selection_v1.h>
 #include <wlr/util/log.h>
 #include <wlr/version.h>
 #include <wordexp.h>
@@ -662,6 +663,8 @@ void viv_server_init(struct viv_server *server) {
 	wlr_data_device_manager_create(server->wl_display);
 
     wlr_screencopy_manager_v1_create(server->wl_display);
+
+    wlr_primary_selection_v1_device_manager_create(server->wl_display);
 
     // Create an output layout, for handling the arrangement of multiple outputs
 	server->output_layout = wlr_output_layout_create();


### PR DESCRIPTION
Implements the primary selection protocol

Also functions as a workaround for this annoying firefox bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=1731511

This can be tested by trying to copy across different views using the middle mouse button. Firefox issue can be tested by trying to copy straight from the address bar into another app using any method, without the workaround, it is only able to paste onto Firefox itself.