### PR TITLE
Ensure focus consistency

### DIFF
--- a/include/viv_seat.h
+++ b/include/viv_seat.h
@@ -7,8 +7,11 @@ struct viv_seat *viv_seat_create(struct viv_server *server, char *name);
 
 void viv_seat_begin_interactive(struct viv_seat *seat, struct viv_view *view, enum viv_cursor_mode mode, uint32_t edges);
 
-/// Give keyboard focus to the given surface
-void viv_seat_focus_surface(struct viv_seat *seat, struct wlr_surface *surface);
+/// Give keyboard focus to the given layer_view
+void viv_seat_focus_layer_view(struct viv_seat *seat, struct viv_layer_view *view);
+
+/// Give keyboard focus to the given view
+void viv_seat_focus_view(struct viv_seat *seat, struct viv_view *view);
 
 /// Create a new viv_keyboard in the given seat
 void viv_seat_create_new_keyboard(struct viv_seat *seat, struct wlr_input_device *device);

--- a/include/viv_seat.h
+++ b/include/viv_seat.h
@@ -13,6 +13,9 @@ void viv_seat_focus_layer_view(struct viv_seat *seat, struct viv_layer_view *vie
 /// Give keyboard focus to the given view
 void viv_seat_focus_view(struct viv_seat *seat, struct viv_view *view);
 
+/// Clear the focus
+void viv_seat_clear_focus(struct viv_seat *seat);
+
 /// Create a new viv_keyboard in the given seat
 void viv_seat_create_new_keyboard(struct viv_seat *seat, struct wlr_input_device *device);
 

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -189,7 +189,6 @@ struct viv_view_implementation {
     void (*get_geometry)(struct viv_view *view, struct wlr_box *geo_box);
     void (*set_tiled)(struct viv_view *view, uint32_t edges);
     void (*get_string_identifier)(struct viv_view *view, char *output, size_t max_len);
-    void (*set_activated)(struct viv_view *view, bool activated);
     struct wlr_surface *(*get_toplevel_surface)(struct viv_view *view);
     void (*close)(struct viv_view *view);
     bool (*is_at)(struct viv_view *view, double lx, double ly, struct wlr_surface **surface, double *sx, double *sy);

--- a/include/viv_view.h
+++ b/include/viv_view.h
@@ -11,9 +11,9 @@ void viv_view_bring_to_front(struct viv_view *view);
 /// Clear focus from all views handled by the server;
 void viv_view_clear_all_focus(struct viv_server *server);
 
-/// Make the given view and surface the current focus of keyboard input, and the active
+/// Make the given view the current focus of keyboard input, and the active
 /// view in the current workspace
-void viv_view_focus(struct viv_view *view, struct wlr_surface *surface);
+void viv_view_focus(struct viv_view *view);
 
 /// Mark the given view as floating, and trigger a workspace layout update if necessary
 void viv_view_ensure_floating(struct viv_view *view);

--- a/include/viv_view.h
+++ b/include/viv_view.h
@@ -46,9 +46,6 @@ bool viv_view_oversized(struct viv_view *view);
 /// Mark the view as damaged on every output
 void viv_view_damage(struct viv_view *view);
 
-/// Make the given view the active view within its workspace
-void viv_view_make_active(struct viv_view *view);
-
 /// Set the size of a view
 void viv_view_set_size(struct viv_view *view, uint32_t width, uint32_t height);
 
@@ -64,8 +61,6 @@ void viv_view_init(struct viv_view *view, struct viv_server *server);
 
 /// Clear up view state, remove it from its workspace, and free its memory
 void viv_view_destroy(struct viv_view *view);
-
-void viv_view_set_activated(struct viv_view *view, bool activated);
 
 /// Get the wlr_surface that is the main/toplevel surface for this view
 struct wlr_surface *viv_view_get_toplevel_surface(struct viv_view *view);

--- a/include/viv_workspace.h
+++ b/include/viv_workspace.h
@@ -8,8 +8,6 @@ void viv_workspace_increment_divide(struct viv_workspace *workspace, float incre
 
 void viv_workspace_increment_counter(struct viv_workspace *workspace, uint32_t increment);
 
-void viv_workspace_swap_out(struct viv_output *output, struct wl_list *workspaces);
-
 void viv_workspace_focus_next_window(struct viv_workspace *workspace);
 void viv_workspace_focus_prev_window(struct viv_workspace *workspace);
 

--- a/src/viv_cursor.c
+++ b/src/viv_cursor.c
@@ -132,7 +132,7 @@ static void process_cursor_pass_through_to_surface(struct viv_seat *seat, uint32
         }
 
         if ((view != active_view) && server->config->focus_follows_mouse) {
-            viv_view_focus(view, surface);
+            viv_view_focus(view);
         }
     } else {
         // No focusable surface under the cursor => use the default image

--- a/src/viv_cursor.c
+++ b/src/viv_cursor.c
@@ -119,7 +119,7 @@ static void process_cursor_pass_through_to_surface(struct viv_seat *seat, uint32
     // Act appropriately on whatever view type was found
     if (layer_view) {
         if (layer_view_wants_keyboard_focus(layer_view)) {
-            viv_seat_focus_surface(seat, surface);
+            viv_seat_focus_layer_view(seat, layer_view);
             server->active_output->current_workspace->active_view = NULL;
         }
     } else if (view) {

--- a/src/viv_layer_view.c
+++ b/src/viv_layer_view.c
@@ -58,7 +58,7 @@ static void layer_surface_unmap(struct wl_listener *listener, void *data) {
     }
 
     if (active_view != NULL) {
-        viv_view_focus(active_view, NULL);
+        viv_view_focus(active_view);
     }
 
     if (layer_view->surface_tree) {

--- a/src/viv_layer_view.c
+++ b/src/viv_layer_view.c
@@ -33,7 +33,7 @@ static void layer_surface_map(struct wl_listener *listener, void *data) {
 
     if (layer_view->layer_surface->current.keyboard_interactive) {
         struct viv_seat *seat = viv_server_get_default_seat(layer_view->server);
-        viv_seat_focus_surface(seat, layer_view->layer_surface->surface);
+        viv_seat_focus_layer_view(seat, layer_view);
     }
 }
 

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -241,6 +241,10 @@ void viv_output_display_workspace(struct viv_output *output, struct viv_workspac
     } else {
         viv_view_clear_all_focus(output->server);
     }
+
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    viv_cursor_reset_focus(workspace->server, (int64_t)now.tv_sec * 1000 + now.tv_nsec / 1000000);
 }
 
 void viv_output_init(struct viv_output *output, struct viv_server *server, struct wlr_output *wlr_output) {

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -181,7 +181,7 @@ void viv_output_make_active(struct viv_output *output) {
     viv_output_damage(output->server->active_output);
 
     if (output->current_workspace->active_view) {
-        viv_view_focus(output->current_workspace->active_view, NULL);
+        viv_view_focus(output->current_workspace->active_view);
     }
 }
 
@@ -237,7 +237,7 @@ void viv_output_display_workspace(struct viv_output *output, struct viv_workspac
     viv_output_mark_for_relayout(output);
 
     if (workspace->active_view) {
-        viv_view_focus(workspace->active_view, NULL);
+        viv_view_focus(workspace->active_view);
     } else {
         viv_view_clear_all_focus(output->server);
     }

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -232,15 +232,15 @@ void viv_output_display_workspace(struct viv_output *output, struct viv_workspac
         output->current_workspace->output = NULL;
     }
 
+    output->current_workspace = workspace;
+    output->current_workspace->output = output;
+    viv_output_mark_for_relayout(output);
+
     if (workspace->active_view) {
         viv_view_focus(workspace->active_view, NULL);
     } else {
         viv_view_clear_all_focus(output->server);
     }
-
-    output->current_workspace = workspace;
-    output->current_workspace->output = output;
-    viv_output_mark_for_relayout(output);
 }
 
 void viv_output_init(struct viv_output *output, struct viv_server *server, struct wlr_output *wlr_output) {

--- a/src/viv_seat.c
+++ b/src/viv_seat.c
@@ -389,7 +389,7 @@ static void seat_cursor_button(struct wl_listener *listener, void *data) {
         }
 
         if (view != active_view) {
-            viv_view_focus(view, surface);
+            viv_view_focus(view);
         }
 
         // If making a window floating, always bring it to the front

--- a/src/viv_seat.c
+++ b/src/viv_seat.c
@@ -143,8 +143,7 @@ void viv_seat_create_new_keyboard(struct viv_seat *seat, struct wlr_input_device
 	/* And add the keyboard to our list of keyboards */
 	wl_list_insert(&seat->keyboards, &keyboard->link);
 }
-
-void viv_seat_focus_surface(struct viv_seat *seat, struct wlr_surface *surface) {
+static void focus_surface(struct viv_seat *seat, struct wlr_surface *surface) {
     ASSERT(surface != NULL);
     struct wlr_seat *wlr_seat = seat->wlr_seat;
 	struct wlr_surface *prev_surface = wlr_seat->keyboard_state.focused_surface;
@@ -156,6 +155,23 @@ void viv_seat_focus_surface(struct viv_seat *seat, struct wlr_surface *surface) 
     if (!viv_seat_input_allowed(seat, surface)) {
         wlr_log(WLR_DEBUG, "Denied focus change to surface %p, surface not owned by the exclusive client", surface);
         return;
+    }
+
+    if (wlr_surface_is_xdg_surface(surface)) {
+        struct wlr_xdg_surface *next = wlr_xdg_surface_from_wlr_surface(surface);
+        wlr_xdg_toplevel_set_activated(next, true);
+#ifdef XWAYLAND
+    } else if (wlr_surface_is_xwayland_surface(surface)) {
+        struct wlr_xwayland_surface *next = wlr_xwayland_surface_from_wlr_surface(surface);
+
+        // Don't change focus for popups
+        if (next->override_redirect) {
+            return;
+        }
+
+        wlr_xwayland_surface_activate(next, true);
+        wlr_xwayland_surface_restack(next, NULL, XCB_STACK_MODE_ABOVE);
+#endif
     }
 
 	if (prev_surface) {
@@ -170,16 +186,15 @@ void viv_seat_focus_surface(struct viv_seat *seat, struct wlr_surface *surface) 
             wlr_xdg_toplevel_set_activated(previous, false);
 #ifdef XWAYLAND
         } else if (wlr_surface_is_xwayland_surface(focused_surface)) {
-            // TODO: Deactivating the previous xwayland surface appears wrong - it makes
-            // chromium popups disappear. Maybe we have some other logic issue.
-            /* struct wlr_xwayland_surface *previous = wlr_xwayland_surface_from_wlr_surface(focused_surface); */
-            /* wlr_xwayland_surface_activate(previous, false); */
+            struct wlr_xwayland_surface *previous = wlr_xwayland_surface_from_wlr_surface(focused_surface);
+            wlr_xwayland_surface_activate(previous, false);
 #endif
         } else {
             // Not an error as this could be a layer surface
             wlr_log(WLR_DEBUG, "Could not deactivate previous keyboard-focused surface");
         }
 	}
+
 	struct wlr_keyboard *keyboard = wlr_seat_get_keyboard(wlr_seat);
 
 	/*
@@ -188,6 +203,14 @@ void viv_seat_focus_surface(struct viv_seat *seat, struct wlr_surface *surface) 
 	 * clients without additional work on your part.
 	 */
 	wlr_seat_keyboard_notify_enter(wlr_seat, surface, keyboard->keycodes, keyboard->num_keycodes, &keyboard->modifiers);
+}
+
+void viv_seat_focus_view(struct viv_seat *seat, struct viv_view *view) {
+  focus_surface(seat, viv_view_get_toplevel_surface(view));
+}
+
+void viv_seat_focus_layer_view(struct viv_seat *seat, struct viv_layer_view *view) {
+  focus_surface(seat, view->layer_surface->surface);
 }
 
 void viv_seat_set_exclusive_client(struct viv_seat *seat, struct wl_client *client) {

--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -48,8 +48,10 @@ void viv_view_focus(struct viv_view *view, struct wlr_surface *surface) {
 
 	/* Activate the new surface */
     view->workspace->active_view = view;
-    viv_seat_focus_surface(viv_server_get_default_seat(server), surface);
-    viv_view_set_activated(view, true);
+    if (server->active_output->current_workspace == view->workspace) {
+        // Prevent focus from leaving current workspace
+        viv_seat_focus_view(viv_server_get_default_seat(server), view);
+    }
 }
 
 struct wlr_surface *viv_view_get_toplevel_surface(struct viv_view *view) {
@@ -200,11 +202,6 @@ void viv_view_damage(struct viv_view *view) {
     }
 }
 
-void viv_view_make_active(struct viv_view *view) {
-    view->workspace->active_view = view;
-    viv_view_focus(view, view->xdg_surface->surface);
-}
-
 void viv_view_set_size(struct viv_view *view, uint32_t width, uint32_t height) {
     ASSERT(view->implementation->set_size != NULL);
     view->implementation->set_size(view, width, height);
@@ -261,10 +258,6 @@ void viv_view_destroy(struct viv_view *view) {
     }
 
 	free(view);
-}
-
-void viv_view_set_activated(struct viv_view *view, bool activated) {
-    view->implementation->set_activated(view, activated);
 }
 
 bool viv_view_is_at(struct viv_view *view, double lx, double ly, struct wlr_surface **surface, double *sx, double *sy) {

--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -30,13 +30,10 @@ void viv_view_clear_all_focus(struct viv_server *server) {
     viv_seat_clear_focus(seat);
 }
 
-void viv_view_focus(struct viv_view *view, struct wlr_surface *surface) {
+void viv_view_focus(struct viv_view *view) {
 	if (view == NULL) {
 		return;
 	}
-    if (surface == NULL) {
-        surface = viv_view_get_toplevel_surface(view);
-    }
 	struct viv_server *server = view->server;
 
     // Damage both previous and newly-active surface
@@ -105,7 +102,7 @@ void viv_view_shift_to_workspace(struct viv_view *view, struct viv_workspace *wo
     wl_list_insert(&workspace->views, &view->workspace_link);
 
     if (next_view != NULL) {
-        viv_view_focus(next_view, NULL);
+        viv_view_focus(next_view);
     } else {
         viv_view_clear_all_focus(view->server);
     }

--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -27,7 +27,7 @@ void viv_view_bring_to_front(struct viv_view *view) {
 
 void viv_view_clear_all_focus(struct viv_server *server) {
     struct viv_seat *seat = viv_server_get_default_seat(server);
-    wlr_seat_keyboard_notify_clear_focus(seat->wlr_seat);
+    viv_seat_clear_focus(seat);
 }
 
 void viv_view_focus(struct viv_view *view, struct wlr_surface *surface) {

--- a/src/viv_workspace.c
+++ b/src/viv_workspace.c
@@ -28,7 +28,7 @@ void viv_workspace_focus_next_window(struct viv_workspace *workspace) {
     }
 
     if (next_view) {
-        viv_view_focus(next_view, viv_view_get_toplevel_surface(next_view));
+        viv_view_focus(next_view);
     } else {
         wlr_log(WLR_DEBUG, "Could not get next window, no active view");
     }
@@ -44,7 +44,7 @@ void viv_workspace_focus_prev_window(struct viv_workspace *workspace) {
     }
 
     if (prev_view) {
-        viv_view_focus(prev_view, viv_view_get_toplevel_surface(prev_view));
+        viv_view_focus(prev_view);
     } else {
         wlr_log(WLR_DEBUG, "Could not get prev window, no active view");
     }
@@ -244,7 +244,7 @@ void viv_workspace_add_view(struct viv_workspace *workspace, struct viv_view *vi
     }
 
     if (!workspace->fullscreen_view || (workspace->fullscreen_view == view)) {
-        viv_view_focus(view, viv_view_get_toplevel_surface(view));
+        viv_view_focus(view);
     }
 
     viv_workspace_mark_for_relayout(workspace);

--- a/src/viv_workspace.c
+++ b/src/viv_workspace.c
@@ -113,33 +113,6 @@ void viv_workspace_increment_counter(struct viv_workspace *workspace, uint32_t i
     viv_workspace_mark_for_relayout(workspace);
 }
 
-void viv_workspace_swap_out(struct viv_output *output, struct wl_list *workspaces) {
-    if (wl_list_length(workspaces) < 2) {
-        wlr_log(WLR_DEBUG, "Not switching workspaces as only %d present\n", wl_list_length(workspaces));
-        return;
-    }
-
-    struct wl_list *new_workspace_link = workspaces->prev;
-
-    struct viv_workspace *new_workspace = wl_container_of(new_workspace_link, new_workspace, server_link);
-    struct viv_workspace *old_workspace = wl_container_of(workspaces->next, old_workspace, server_link);
-
-    wl_list_remove(new_workspace_link);
-    wl_list_insert(workspaces, new_workspace_link);
-
-    old_workspace->output = NULL;
-    new_workspace->output = output;
-    output->current_workspace = new_workspace;
-
-    viv_output_mark_for_relayout(output);
-
-    if (new_workspace->active_view != NULL) {
-        viv_view_focus(new_workspace->active_view, viv_view_get_toplevel_surface(new_workspace->active_view));
-    }
-
-    wlr_log(WLR_INFO, "Workspace changed from %s to %s", old_workspace->name, new_workspace->name);
-}
-
 void viv_workspace_next_layout(struct viv_workspace *workspace) {
     struct wl_list *next_layout_link = workspace->active_layout->workspace_link.next;
     if (next_layout_link == &workspace->layouts) {

--- a/src/viv_xdg_shell.c
+++ b/src/viv_xdg_shell.c
@@ -292,10 +292,6 @@ static void implementation_get_string_identifier(struct viv_view *view, char *ou
              view->xdg_surface->toplevel->title);
 }
 
-static void implementation_set_activated(struct viv_view *view, bool activated) {
-	wlr_xdg_toplevel_set_activated(view->xdg_surface, activated);
-}
-
 static struct wlr_surface *implementation_get_toplevel_surface(struct viv_view *view) {
     return view->xdg_surface->surface;
 }
@@ -390,7 +386,6 @@ static struct viv_view_implementation xdg_view_implementation = {
     .get_geometry = &implementation_get_geometry,
     .set_tiled = &implementation_set_tiled,
     .get_string_identifier = &implementation_get_string_identifier,
-    .set_activated = &implementation_set_activated,
     .get_toplevel_surface = &implementation_get_toplevel_surface,
     .close = &implementation_close,
     .is_at = &implementation_is_at,

--- a/src/viv_xwayland_shell.c
+++ b/src/viv_xwayland_shell.c
@@ -300,13 +300,6 @@ static void implementation_get_string_identifier(struct viv_view *view, char *ou
              view->xwayland_surface->class);
 }
 
-static void implementation_set_activated(struct viv_view *view, bool activated) {
-	wlr_xwayland_surface_activate(view->xwayland_surface, activated);
-    if (activated) {
-        wlr_xwayland_surface_restack(view->xwayland_surface, NULL, XCB_STACK_MODE_ABOVE);
-    }
-}
-
 static struct wlr_surface *implementation_get_toplevel_surface(struct viv_view *view) {
     return view->xwayland_surface->surface;
 }
@@ -392,7 +385,6 @@ static struct viv_view_implementation xwayland_view_implementation = {
     .get_geometry = &implementation_get_geometry,
     .set_tiled = &implementation_set_tiled,
     .get_string_identifier = &implementation_get_string_identifier,
-    .set_activated = &implementation_set_activated,
     .get_toplevel_surface = &implementation_get_toplevel_surface,
     .close = &implementation_close,
     .is_at = &implementation_is_at,


### PR DESCRIPTION
- Centralizes the keyboard focus workflow, so that it happens through a single function, where we can ensure the focus dance follows all steps. This addresses bugs including #114;
- Makes it so xwayland surfaces can be deactivated. This fixes bugs when, for example, using Slack, where notifications would automatically be consumed, and the status would always be set to available;
- Touches up mouse focusing on workspace switch #88.

I've been using this daily, and it seems stable and correct.