### PR TITLE
Add pointer acceleration config support

### DIFF
--- a/include/viv_config_types.h
+++ b/include/viv_config_types.h
@@ -34,6 +34,8 @@ struct viv_libinput_config {
     enum libinput_config_click_method click_method;
     enum libinput_config_tap_state tap_to_click;
     enum libinput_config_tap_button_map tap_button_map;
+    enum libinput_config_accel_profile accel_profile;
+    double accel_speed;
 };
 
 #endif

--- a/src/viv_input.c
+++ b/src/viv_input.c
@@ -17,6 +17,9 @@ static void configure_libinput_device(struct libinput_device *device, struct viv
     libinput_device_config_click_set_method(device, config->click_method);
     libinput_device_config_tap_set_enabled(device, config->tap_to_click);
     libinput_device_config_tap_set_button_map(device, config->tap_button_map);
+    libinput_device_config_tap_set_button_map(device, config->tap_button_map);
+    libinput_device_config_accel_set_profile(device, config->accel_profile);
+    libinput_device_config_accel_set_speed(device, config->accel_speed);
 }
 
 static void try_configure_libinput_device(struct wlr_input_device *device, struct viv_libinput_config *libinput_configs) {


### PR DESCRIPTION
I saw this request on IRC and though it would be a good way to get started with hacking on vivarium. This pull request adds config options for libinput’s different acceleration modes and speed.