### PR TITLE
Ensure keyboard is not NULL before sending enter notification

### DIFF
--- a/src/viv_seat.c
+++ b/src/viv_seat.c
@@ -208,7 +208,9 @@ static void focus_surface(struct viv_seat *seat, struct wlr_surface *surface) {
 	 * track of this and automatically send key events to the appropriate
 	 * clients without additional work on your part.
 	 */
-	wlr_seat_keyboard_notify_enter(wlr_seat, surface, keyboard->keycodes, keyboard->num_keycodes, &keyboard->modifiers);
+    if (keyboard) {
+        wlr_seat_keyboard_notify_enter(wlr_seat, surface, keyboard->keycodes, keyboard->num_keycodes, &keyboard->modifiers);
+    }
 }
 
 void viv_seat_focus_view(struct viv_seat *seat, struct viv_view *view) {


### PR DESCRIPTION
Ensures keyboard notification enter events are only sent to valid keyboards. Null values could be seen when focus was changed using the mouse after unplugging a keyboard.

----

To test:

1. Use keyboard;
2. Open 2 views;
3. Focus one of them;
4. Unplug keyboard that was last used;
5. Click the other view;
6. Watch segfault before this change, or no segfault with it.