### PR TITLE
WIP: Output management take 2

### DIFF
--- a/include/viv_server.h
+++ b/include/viv_server.h
@@ -49,4 +49,6 @@ void viv_server_clear_view_from_grab_state(struct viv_server *server, struct viv
 bool viv_server_any_seat_grabs(struct viv_server *server, struct viv_view *view);
 
 void viv_server_update_idle_inhibitor_state(struct viv_server *server);
+
+void viv_server_update_output_manager_config(struct viv_server *server);
 #endif

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -88,6 +88,10 @@ struct viv_server {
     struct wl_listener input_inhibit_activate;
     struct wl_listener input_inhibit_deactivate;
 
+    struct wlr_output_manager_v1 *output_manager;
+    struct wl_listener output_manager_apply;
+    struct wl_listener output_manager_test;
+
 	struct wlr_output_layout *output_layout;
     struct viv_output *active_output;
 	struct wl_list outputs;

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -127,6 +127,8 @@ struct viv_output {
 	struct viv_server *server;
 	struct wlr_output *wlr_output;
 
+    bool enabled;
+
 	struct wl_listener frame;
 	struct wl_listener damage_event;
 	struct wl_listener present;

--- a/include/viv_types.h
+++ b/include/viv_types.h
@@ -128,6 +128,7 @@ struct viv_output {
 	struct wlr_output *wlr_output;
 
     bool enabled;
+    bool powered_down;
 
 	struct wl_listener frame;
 	struct wl_listener damage_event;

--- a/src/viv_damage.c
+++ b/src/viv_damage.c
@@ -17,7 +17,9 @@ void viv_damage_surface(struct viv_server *server, struct wlr_surface *surface, 
 
     struct viv_output *output;
     wl_list_for_each(output, &server->outputs, link) {
-        viv_output_damage_layout_coords_region(output, &damage);
+        if (output->enabled) {
+            viv_output_damage_layout_coords_region(output, &damage);
+        }
     }
 
     pixman_region32_fini(&damage);

--- a/src/viv_layer_view.c
+++ b/src/viv_layer_view.c
@@ -76,8 +76,7 @@ static void layer_surface_destroy(struct wl_listener *listener, void *data) {
 
     // TODO: unfocus this as the keyboard surface if necessary
 
-	wl_list_remove(&layer_view->output_link);
-
+    wl_list_remove(&layer_view->output_link);
     viv_output_mark_for_relayout(layer_view->output);
 
     if (layer_view->surface_tree) {
@@ -116,8 +115,10 @@ static void layer_surface_surface_commit(struct wl_listener *listener, void *dat
     }
 
     layer_view->mapped = layer_view->layer_surface->mapped;
-    viv_layers_arrange(layer_view->output);
-    viv_output_mark_for_relayout(layer_view->output);
+    if (layer_view->output) {
+      viv_layers_arrange(layer_view->output);
+      viv_output_mark_for_relayout(layer_view->output);
+    }
 }
 
 void viv_layer_view_init(struct viv_layer_view *layer_view, struct viv_server *server, struct wlr_layer_surface_v1 *layer_surface) {

--- a/src/viv_mappable_functions.c
+++ b/src/viv_mappable_functions.c
@@ -327,7 +327,9 @@ void viv_mappable_debug_damage_all(struct viv_workspace *workspace, union viv_ma
 
     struct viv_output *output;
     wl_list_for_each(output, &server->outputs, link) {
-        viv_output_damage(output);
+        if (output->enabled) {
+            viv_output_damage(output);
+        }
     }
 }
 
@@ -341,7 +343,9 @@ void viv_mappable_debug_toggle_show_undamaged_regions(struct viv_workspace *work
     workspace->server->config->debug_mark_undamaged_regions = !workspace->server->config->debug_mark_undamaged_regions;
     struct viv_output *output;
     wl_list_for_each(output, &workspace->server->outputs, link) {
-        viv_output_damage(output);
+        if (output->enabled) {
+            viv_output_damage(output);
+        }
     }
 }
 

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -81,6 +81,10 @@ static void output_frame(struct wl_listener *listener, void *data) {
     // This has been called because a specific output is ready to display a frame,
     // retrieve this info
 	struct viv_output *output = wl_container_of(listener, output, frame);
+    if (!output->enabled) {
+        return;
+    }
+
 	struct wlr_renderer *renderer = output->server->renderer;
 
 #ifdef DEBUG
@@ -161,6 +165,8 @@ static void output_destroy(struct wl_listener *listener, void *data) {
     wl_list_remove(&output->destroy.link);
 
     free(output);
+
+    viv_server_update_output_manager_config(output->server);
 }
 
 struct viv_output *viv_output_at(struct viv_server *server, double lx, double ly) {

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -196,7 +196,15 @@ static void output_destroy(struct wl_listener *listener, void *data) {
         }
         if (!wl_list_empty(&server->outputs) && !num_left_enabled) {
             struct viv_output *first_output = wl_container_of(server->outputs.next, first_output, link);
+            wlr_log(WLR_INFO, "Last enabled output destroyed. Enabling %s", first_output->wlr_output->name);
+
+            // TODO: in the future we might want to read the mode from the config file
+            struct wlr_output_mode *mode = wlr_output_preferred_mode(first_output->wlr_output);
+            wlr_output_set_mode(first_output->wlr_output, mode);
             wlr_output_enable(first_output->wlr_output, true);
+            if (!wlr_output_commit(first_output->wlr_output)) {
+                wlr_log(WLR_INFO, "Failed to commit changes to %s", first_output->wlr_output->name);
+            }
         }
     }
 }

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -172,9 +172,9 @@ static void output_destroy(struct wl_listener *listener, void *data) {
     wl_list_remove(&output->mode.link);
     wl_list_remove(&output->destroy.link);
 
-    free(output);
-
     viv_server_update_output_manager_config(output->server);
+
+    free(output);
 }
 
 struct viv_output *viv_output_at(struct viv_server *server, double lx, double ly) {

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -52,8 +52,8 @@ static void stop_using_output(struct viv_output *output) {
     // Clean up layer views
     struct viv_layer_view *layer_view, *tmp;
     wl_list_for_each_safe(layer_view, tmp, &output->layer_views, output_link){
-        wlr_layer_surface_v1_destroy(layer_view->layer_surface);
         layer_view->output = NULL;
+        wlr_layer_surface_v1_destroy(layer_view->layer_surface);
     }
 
     if (server->active_output == output) {
@@ -349,10 +349,19 @@ void viv_output_damage(struct viv_output *output) {
         wlr_log(WLR_ERROR, "Tried to damage NULL output");
         return;
     }
+    if (!output->enabled) {
+        wlr_log(WLR_ERROR, "Tried to damage disabled output");
+        return;
+    }
     wlr_output_damage_add_whole(output->damage);
 }
 
 void viv_output_damage_layout_coords_box(struct viv_output *output, struct wlr_box *box) {
+    if (!output->enabled) {
+        wlr_log(WLR_ERROR, "Tried to damage box in disabled output");
+        return;
+    }
+
     struct wlr_box scaled_box;
     memcpy(&scaled_box, box, sizeof(struct wlr_box));
 

--- a/src/viv_output.c
+++ b/src/viv_output.c
@@ -127,8 +127,16 @@ static void output_enable(struct wl_listener *listener, void *data) {
     UNUSED(data);
     struct viv_output *output = wl_container_of(listener, output, enable);
 
-    bool enabled = output->wlr_output->enabled;
-    wlr_log(WLR_INFO, "Output \"%s\" event: enable became %d", output->wlr_output->name, enabled);
+    bool enabled = output->wlr_output->enabled || output->powered_down;
+    wlr_log(WLR_INFO,
+        "Output \"%s\" event: enable became %d, power is %d",
+        output->wlr_output->name, output->wlr_output->enabled,
+        output->powered_down);
+
+    if (output->powered_down) {
+        wlr_log(WLR_DEBUG, "Not acting on changes to powered down outputs");
+        return;
+    }
 
     if (output->enabled == enabled) {
         wlr_log(WLR_ERROR, "Asked to set enable %d for output %p but this was already set", enabled, output);

--- a/src/viv_render.c
+++ b/src/viv_render.c
@@ -619,4 +619,18 @@ void viv_render_output(struct wlr_renderer *renderer, struct viv_output *output)
         // Damage the full output so that it will be drawn again next frame
         viv_output_damage(output);
     }
+
+    static int count = 0;
+    count++;
+    if (count % 200 == 0) {
+        struct viv_output *out;
+        wl_list_for_each(out, &server->outputs, link) {
+            wlr_log(WLR_INFO, "Output name \"%s\" description \"%s\" make \"%s\" model \"%s\" serial \"%s\"",
+                    out->wlr_output->name,
+                    out->wlr_output->description ? out->wlr_output->description : "",
+                    out->wlr_output->make,
+                    out->wlr_output->model,
+                    out->wlr_output->serial);
+        }
+    }
 }

--- a/src/viv_render.c
+++ b/src/viv_render.c
@@ -525,7 +525,7 @@ void viv_render_output(struct wlr_renderer *renderer, struct viv_output *output)
         // Render floating views that may be overhanging other workspaces
         struct viv_output *other_output;
         wl_list_for_each(other_output, &output->server->outputs, link) {
-            if (other_output == output) {
+            if (other_output == output || !other_output->enabled) {
                 continue;
             }
             struct viv_workspace *other_workspace = other_output->current_workspace;
@@ -618,19 +618,5 @@ void viv_render_output(struct wlr_renderer *renderer, struct viv_output *output)
     if (server->config->damage_tracking_mode == VIV_DAMAGE_TRACKING_NONE) {
         // Damage the full output so that it will be drawn again next frame
         viv_output_damage(output);
-    }
-
-    static int count = 0;
-    count++;
-    if (count % 200 == 0) {
-        struct viv_output *out;
-        wl_list_for_each(out, &server->outputs, link) {
-            wlr_log(WLR_INFO, "Output name \"%s\" description \"%s\" make \"%s\" model \"%s\" serial \"%s\"",
-                    out->wlr_output->name,
-                    out->wlr_output->description ? out->wlr_output->description : "",
-                    out->wlr_output->make,
-                    out->wlr_output->model,
-                    out->wlr_output->serial);
-        }
     }
 }

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -695,14 +695,10 @@ static bool test_queued_configuration(struct viv_server *server, struct wlr_outp
     return true;
 }
 
-static void rollback_queued_configuration(struct viv_server *server, struct wlr_output_configuration_v1 *output_config) {
+static void rollback_queued_configuration(struct wlr_output_configuration_v1 *output_config) {
     struct wlr_output_head_v1 *head;
     wl_list_for_each(head, &output_config->heads, link) {
         wlr_output_rollback(head->state.output);
-
-        // Also re-enable or disable as this isn't rolled back implicitly
-        struct viv_output *output = viv_output_of_wlr_output(server, head->state.output);
-        wlr_output_enable(output->wlr_output, output->enabled);
     }
 }
 
@@ -722,17 +718,13 @@ static void handle_output_manager_apply(struct wl_listener *listener, void *data
     wlr_log(WLR_INFO, "Received output manager apply request");
 
     queue_output_configuration(server, output_config);
-    bool config_good = test_queued_configuration(server, output_config);
-    if (config_good) {
-        wlr_log(WLR_ERROR, "Test passed for new output config");
-        bool commit_success = commit_new_output_configuration(output_config);
-        if (!commit_success) {
-            wlr_log(WLR_ERROR, "Some new output state failed to to commit");
-        }
+    bool commit_success = commit_new_output_configuration(output_config);
+    if (commit_success) {
+        wlr_log(WLR_INFO, "Commit succeeded for new output config");
         wlr_output_configuration_v1_send_succeeded(output_config);
     } else {
-        wlr_log(WLR_ERROR, "Test failed for new output config");
-        rollback_queued_configuration(server, output_config) ;
+        wlr_log(WLR_ERROR, "Some new output state failed to to commit");
+        rollback_queued_configuration(output_config) ;
         wlr_output_configuration_v1_send_failed(output_config);
     }
 
@@ -741,8 +733,11 @@ static void handle_output_manager_apply(struct wl_listener *listener, void *data
         struct viv_output *output = viv_output_of_wlr_output(server, head->state.output);
         wlr_log(WLR_INFO, "Setting output %p layout pos to %d,%d", output, head->state.x, head->state.y);
         wlr_output_layout_add(server->output_layout, output->wlr_output, head->state.x, head->state.y);
+        viv_output_mark_for_relayout(output);
         viv_output_damage(output);
     }
+
+	wlr_output_configuration_v1_destroy(output_config);
 
     viv_server_update_output_manager_config(server);
 }
@@ -750,21 +745,20 @@ static void handle_output_manager_apply(struct wl_listener *listener, void *data
 static void handle_output_manager_test(struct wl_listener *listener, void *data) {
 	struct viv_server *server = wl_container_of(listener, server, output_manager_test);
     struct wlr_output_configuration_v1 *output_config = data;
-    wlr_output_configuration_v1_send_succeeded(output_config);
     wlr_log(WLR_INFO, "Received output manager test request");
 
-    wlr_log(WLR_INFO, "Received output manager apply request");
-
     queue_output_configuration(server, output_config);
-    bool config_good = test_queued_configuration(server, output_config);
-    if (config_good) {
+    bool test_success = test_queued_configuration(server, output_config);
+    if (test_success) {
         wlr_log(WLR_ERROR, "Test passed for new output config");
         wlr_output_configuration_v1_send_succeeded(output_config);
     } else {
         wlr_log(WLR_ERROR, "Test failed for new output config");
         wlr_output_configuration_v1_send_failed(output_config);
     }
-    rollback_queued_configuration(server, output_config) ;
+    rollback_queued_configuration(output_config) ;
+
+	wlr_output_configuration_v1_destroy(output_config);
 }
 
 /** Initialise the viv_server by setting up all the global state: the wayland display and

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -347,6 +347,7 @@ bool viv_server_handle_keybinding(struct viv_server *server, uint32_t keycode, x
     struct viv_output *output = server->active_output;
     if (!output) {
         wlr_log(WLR_ERROR, "Ignoring keybinding as no output active to act on");
+        return false;
     }
 
     struct viv_workspace *workspace = output->current_workspace;

--- a/src/viv_server.c
+++ b/src/viv_server.c
@@ -610,10 +610,12 @@ static void handle_input_inhibit_deactivate(struct wl_listener *listener, void *
 }
 
 static void handle_output_power_manager_set_mode(struct wl_listener *listener, void *data) {
-    UNUSED(listener);
+    struct viv_server *server = wl_container_of(listener, server, output_power_manager_set_mode);
 
     struct wlr_output_power_v1_set_mode_event *event = data;
     bool enabling = event->mode == ZWLR_OUTPUT_POWER_V1_MODE_ON;
+    struct viv_output *output = viv_output_of_wlr_output(server, event->output);
+    output->powered_down = !enabling;
 
     wlr_log(WLR_INFO, "Setting %s power mode to %d", event->output->name, enabling);
 

--- a/src/viv_view.c
+++ b/src/viv_view.c
@@ -176,26 +176,23 @@ bool viv_view_oversized(struct viv_view *view) {
 }
 
 void viv_view_damage(struct viv_view *view) {
-    struct viv_output *output;
     struct wlr_box geo_box = { 0 };
-
-    if (view->workspace->fullscreen_view == view) {
-        wl_list_for_each(output, &view->server->outputs, link) {
-            viv_output_damage(output);
-        }
-        return;
-    }
 
     viv_view_get_geometry(view, &geo_box);
 
     int border_width = view->server->config->border_width;
-    geo_box.x -= border_width;
-    geo_box.y -= border_width;
-    geo_box.width += 2 * border_width;
-    geo_box.height += 2 * border_width;
+    if (view->workspace->fullscreen_view != view) {
+        geo_box.x -= border_width;
+        geo_box.y -= border_width;
+        geo_box.width += 2 * border_width;
+        geo_box.height += 2 * border_width;
+    }
 
+    struct viv_output *output;
     wl_list_for_each(output, &view->server->outputs, link) {
-        viv_output_damage_layout_coords_box(output, &geo_box);
+        if (output->enabled) {
+            viv_output_damage_layout_coords_box(output, &geo_box);
+        }
     }
 }
 

--- a/src/viv_wlr_surface_tree.c
+++ b/src/viv_wlr_surface_tree.c
@@ -62,7 +62,9 @@ static void handle_subsurface_unmap (struct wl_listener *listener, void *data) {
 
         struct viv_output *output;
         wl_list_for_each(output, &node->server->outputs, link) {
-            viv_output_damage_layout_coords_box(output, &surface_extents);
+            if (output->enabled) {
+                viv_output_damage_layout_coords_box(output, &surface_extents);
+            }
         }
 
         viv_surface_tree_destroy(subsurface->child);

--- a/src/viv_xdg_popup.c
+++ b/src/viv_xdg_popup.c
@@ -63,7 +63,9 @@ static void handle_popup_surface_unmap(struct wl_listener *listener, void *data)
 
     struct viv_output *output;
     wl_list_for_each(output, &popup->server->outputs, link) {
-        viv_output_damage_layout_coords_box(output, &geo_box);
+        if (output->enabled) {
+            viv_output_damage_layout_coords_box(output, &geo_box);
+        }
     }
 }
 


### PR DESCRIPTION
Getting this out early, as it might benefit others. Builds on top of #79 . It's not perfect yet, but is currently stable enough for someone with two displays to alternate between them with confidence and hopefully no crashes. Trying to use more than one at once is very buggy still, but is functional enough to run `wlr-randr` or `wdisplay` to switch to only one..